### PR TITLE
Add Web Fetch tool — fetches web page content

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -36,7 +36,10 @@ ignore = [
     "S101",
     "ANN201",
     "TRY300",
-    "FBT001"
+    "FBT001",
+    "PLR0911", # too many return statements
+    "D102",    # missing docstring in public method
+    "D107",    # missing docstring in __init__
 ]
 
 [lint.flake8-pytest-style]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Additional tools for LLM-backed Assist for Home Assistant:
 
 * **Web Search** powered by your choice of _Brave_ or _SearXNG_
+* **Web Fetch** — extracts and cleans text content from specific URLs
 * **Location Search** powered by Google Places
 * **Wikipedia**
 * **Weather Forecast**
@@ -142,6 +143,33 @@ Uses a self-hosted SearXNG search service to return summarized results.
 | Setting             | Required | Default | Description                             |
 |---------------------|----------|---------|-----------------------------------------|
 | `Number of Results` | ✅        | `2`     | Number of results to provide to the LLM |
+
+---
+
+### 🌐 Web Fetch
+
+The Web Fetch tool allows the LLM to directly retrieve and process the content of a specific web page. It is ideal for reading articles, documentation, or blog posts from a URL provided in a conversation or found during a web search.
+
+The tool automatically strips unnecessary HTML elements like `<script>`, `<style>`, and `<noscript>`, delivering only readable text to the model to save tokens and improve focus.
+
+#### Configuration Steps
+
+1. This tool is grouped under **Search Services**.
+2. Ensure "Search Services" is enabled in your Conversation Agent configuration.
+
+#### Options
+
+| Setting              | Required | Default | Range          | Description                          |
+|----------------------|----------|---------|----------------|--------------------------------------|
+| `Max Content Length` | ✅        | `10000` | `1000 - 50000` | Maximum characters passed to the LLM |
+
+#### ⚠️ Limitations
+
+To ensure reliable performance, please keep the following in mind:
+*   **Static Content Only:** The tool fetches raw HTML and does not execute JavaScript. Pages relying on client-side rendering (e.g., React, Vue, or SPAs) may return empty or incomplete data.
+*   **Anti-Bot Protection:** While it uses a standard browser User-Agent, it cannot bypass sophisticated security layers like Cloudflare "Under Attack" mode, CAPTCHAs, or strict bot detection.
+*   **No Authentication:** Only publicly accessible pages are supported. The tool does not handle logins, cookies, or private sessions.
+*   **Context Management:** Content is truncated based on the `Max Content Length` setting to stay within the LLM's context window limits.
 
 ---
 

--- a/custom_components/llm_intents/brave_web_search.py
+++ b/custom_components/llm_intents/brave_web_search.py
@@ -82,6 +82,7 @@ class BraveSearchTool(SearchWebTool):
                 results = []
                 for result in response_content.get("web", {}).get("results", []):
                     title = result.get("title", "")
+                    url = result.get("url", "")
                     content = result.get("description", "")
                     extra_snippets = result.get("extra_snippets", [])[
                         0:max_snippets_per_url
@@ -95,7 +96,9 @@ class BraveSearchTool(SearchWebTool):
                     else:
                         result_content = await self.cleanup_text(content)
 
-                    results.append({"title": title, "content": result_content})
+                    results.append(
+                        {"title": title, "url": url, "content": result_content}
+                    )
 
                 return results
             error_msg = f"Web search received a HTTP {resp.status} error from Brave: {response_content}"

--- a/custom_components/llm_intents/config_flow.py
+++ b/custom_components/llm_intents/config_flow.py
@@ -6,18 +6,12 @@ import asyncio
 import logging
 import types
 from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-    from homeassistant.data_entry_flow import FlowResult
-
 from zoneinfo import available_timezones
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.weather import WeatherEntityFeature
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.helpers.selector import (
     EntitySelector,
     EntitySelectorConfig,
@@ -68,6 +62,8 @@ from .const import (
     CONF_UNIT_CONVERTER_ENABLED,
     CONF_WEATHER_ENABLED,
     CONF_WEATHER_TEMPERATURE_SENSOR,
+    CONF_WEB_FETCH_ENABLED,
+    CONF_WEB_FETCH_MAX_CONTENT_LENGTH,
     CONF_WIKIPEDIA_ENABLED,
     CONF_WIKIPEDIA_NUM_RESULTS,
     CONF_YOUTUBE_ENABLED,
@@ -80,7 +76,10 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from homeassistant.config_entries import ConfigEntry, OptionsFlow
+    from homeassistant.data_entry_flow import FlowResult
 
 # Individual steps
 STEP_INIT = "init"
@@ -91,6 +90,7 @@ STEP_SEARXNG = "searxng"
 STEP_GOOGLE_PLACES = "google_places"
 STEP_YOUTUBE = "youtube"
 STEP_WIKIPEDIA = "wikipedia"
+STEP_WEB_FETCH = "web_fetch"
 STEP_WEATHER = "weather"
 STEP_BASIC_UTILITIES = "basic_utilities"
 STEP_CONFIGURE_SEARCH = "configure"
@@ -99,10 +99,9 @@ STEP_CONFIGURE_BASIC_UTILITIES = "configure_basic_utilities"
 
 
 class NullableNumberSelector(NumberSelector):
-    """NumberSelector that allows for empty values."""
+    """Number selector that accepts None values for optional numeric fields."""
 
     def __call__(self, data: Any) -> float | None:
-        """Perform our validation."""
         # Handle for empty values
         if data == "" or data is None:
             return None
@@ -110,17 +109,17 @@ class NullableNumberSelector(NumberSelector):
         value: float = vol.Coerce(float)(data)
 
         if "min" in self.config and value < self.config["min"]:
-            error_msg = f"Value {value} is too small"
-            raise vol.Invalid(error_msg)
+            msg = f"value {value} is too small"
+            raise vol.Invalid(msg)
 
         if "max" in self.config and value > self.config["max"]:
-            error_msg = f"Value {value} is too large"
-            raise vol.Invalid(error_msg)
+            msg = f"value {value} is too large"
+            raise vol.Invalid(msg)
 
         return value
 
 
-def get_step_user_data_schema(hass: HomeAssistant) -> vol.Schema:
+def get_step_user_data_schema(hass) -> vol.Schema:
     """Generate a static schema for the main menu to select services."""
     schema = {
         vol.Optional(
@@ -134,6 +133,7 @@ def get_step_user_data_schema(hass: HomeAssistant) -> vol.Schema:
         vol.Optional(CONF_GOOGLE_PLACES_ENABLED, default=False): bool,
         vol.Optional(CONF_YOUTUBE_ENABLED, default=False): bool,
         vol.Optional(CONF_WIKIPEDIA_ENABLED, default=False): bool,
+        vol.Optional(CONF_WEB_FETCH_ENABLED, default=False): bool,
         vol.Optional(CONF_WEATHER_ENABLED, default=False): bool,
         vol.Optional(CONF_BASIC_UTILITIES_ENABLED, default=False): bool,
     }
@@ -151,6 +151,10 @@ def expand_config_for_schema(config: dict) -> dict:
     provider_keys = config.get(CONF_PROVIDER_API_KEYS) or {}
     result[CONF_GOOGLE_API_KEY] = provider_keys.get(PROVIDER_GOOGLE, "")
     result[CONF_BRAVE_API_KEY] = provider_keys.get(PROVIDER_BRAVE, "")
+    result[CONF_WEB_FETCH_MAX_CONTENT_LENGTH] = (
+        config.get(CONF_WEB_FETCH_MAX_CONTENT_LENGTH)
+        or SERVICE_DEFAULTS.get(CONF_WEB_FETCH_MAX_CONTENT_LENGTH)
+    )
     return result
 
 
@@ -178,9 +182,7 @@ def merge_provider_api_keys_from_input(config_data: dict, user_input: dict) -> N
     config_data.pop(CONF_GOOGLE_PLACES_API_KEY, None)
 
 
-async def get_brave_schema(
-    hass: HomeAssistant, is_llm_context_search: bool
-) -> vol.Schema:
+async def get_brave_schema(hass, is_llm_context_search: bool) -> vol.Schema:
     """Return the static schema for Brave service configuration."""
     iana_timezones = await asyncio.to_thread(available_timezones)
     iana_timezones = sorted(iana_timezones)
@@ -290,7 +292,7 @@ async def get_brave_schema(
     return vol.Schema(schema)
 
 
-async def get_searxng_schema(hass: HomeAssistant) -> vol.Schema:
+async def get_searxng_schema(hass) -> vol.Schema:
     """Return the static schema for the SearXNG service configuration."""
     return vol.Schema(
         {
@@ -313,7 +315,7 @@ async def get_searxng_schema(hass: HomeAssistant) -> vol.Schema:
     )
 
 
-async def get_google_places_schema(hass: HomeAssistant) -> vol.Schema:
+async def get_google_places_schema(hass) -> vol.Schema:
     """Return the static schema for Google Places service configuration."""
     return vol.Schema(
         {
@@ -382,7 +384,7 @@ async def get_google_places_schema(hass: HomeAssistant) -> vol.Schema:
     )
 
 
-async def get_youtube_schema(hass: HomeAssistant) -> vol.Schema:
+async def get_youtube_schema(hass) -> vol.Schema:
     """Return the static schema for YouTube service configuration."""
     return vol.Schema(
         {
@@ -394,7 +396,7 @@ async def get_youtube_schema(hass: HomeAssistant) -> vol.Schema:
     )
 
 
-async def get_wikipedia_schema(hass: HomeAssistant) -> vol.Schema:
+async def get_wikipedia_schema(hass) -> vol.Schema:
     """Return the static schema for Wikipedia service configuration."""
     return vol.Schema(
         {
@@ -414,7 +416,27 @@ async def get_wikipedia_schema(hass: HomeAssistant) -> vol.Schema:
     )
 
 
-async def get_basic_utilities_schema(hass: HomeAssistant) -> vol.Schema:
+async def get_web_fetch_schema(hass) -> vol.Schema:
+    """Return the static schema for Web Fetch service configuration."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_WEB_FETCH_MAX_CONTENT_LENGTH,
+                default=SERVICE_DEFAULTS.get(CONF_WEB_FETCH_MAX_CONTENT_LENGTH),
+            ): NullableNumberSelector(
+                NumberSelectorConfig(
+                    min=1000,
+                    max=50000,
+                    step=500,
+                    mode=NumberSelectorMode.BOX,
+                    unit_of_measurement="Characters",
+                )
+            ),
+        }
+    )
+
+
+async def get_basic_utilities_schema(hass) -> vol.Schema:
     """Return the static schema for Basic Utilities tool configuration."""
     return vol.Schema(
         {
@@ -434,7 +456,7 @@ async def get_basic_utilities_schema(hass: HomeAssistant) -> vol.Schema:
     )
 
 
-async def get_weather_schema(hass: HomeAssistant) -> vol.Schema:
+async def get_weather_schema(hass) -> vol.Schema:
     """Return the static schema for Weather configuration."""
     daily_entities = []
     hourly_entities = []
@@ -483,12 +505,12 @@ async def get_weather_schema(hass: HomeAssistant) -> vol.Schema:
     )
 
 
-async def get_brave_search_schema(hass: HomeAssistant, args=None) -> vol.Schema:
+async def get_brave_search_schema(hass, args=None) -> vol.Schema:
     """Return the static schema for Brave Search configuration."""
     return await get_brave_schema(hass, is_llm_context_search=False)
 
 
-async def get_brave_llm_schema(hass: HomeAssistant, args=None) -> vol.Schema:
+async def get_brave_llm_schema(hass, args=None) -> vol.Schema:
     """Return the static schema for Brave Search configuration."""
     return await get_brave_schema(hass, is_llm_context_search=True)
 
@@ -510,6 +532,7 @@ SEARCH_STEP_ORDER = {
     STEP_GOOGLE_PLACES: [CONF_GOOGLE_PLACES_ENABLED, get_google_places_schema],
     STEP_YOUTUBE: [CONF_YOUTUBE_ENABLED, get_youtube_schema],
     STEP_WIKIPEDIA: [CONF_WIKIPEDIA_ENABLED, get_wikipedia_schema],
+    STEP_WEB_FETCH: [CONF_WEB_FETCH_ENABLED, get_web_fetch_schema],
 }
 
 WEATHER_STEP_ORDER = {
@@ -524,6 +547,7 @@ BASIC_UTILITIES_STEP_ORDER = {
 
 INITIAL_CONFIG_STEP_ORDER = {
     **SEARCH_STEP_ORDER,
+    STEP_WEB_FETCH: [CONF_WEB_FETCH_ENABLED, get_web_fetch_schema],
     STEP_WEATHER: [CONF_WEATHER_ENABLED, get_weather_schema],
     STEP_BASIC_UTILITIES: [CONF_BASIC_UTILITIES_ENABLED, get_basic_utilities_schema],
 }
@@ -595,6 +619,7 @@ class LlmIntentsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial configuration step for the user."""
         # Check if entry already exists
         if self._async_current_entries():
+            # TODO: support a single instance of multiple LLM API types (diff tools) # noqa: TD002,TD003,FIX002
             return self.async_abort(reason="single_instance_allowed")
 
         if user_input is None:
@@ -664,6 +689,12 @@ class LlmIntentsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.FlowResult:
         """Handle Wikipedia configuration step."""
         return await self.handle_step(STEP_WIKIPEDIA, user_input)
+
+    async def async_step_web_fetch(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Handle Web Fetch configuration step."""
+        return await self.handle_step(STEP_WEB_FETCH, user_input)
 
     async def async_step_weather(
         self, user_input: dict[str, Any] | None = None
@@ -741,6 +772,10 @@ class LlmIntentsOptionsFlow(config_entries.OptionsFlowWithReload):
                 ): bool,
                 vol.Optional(
                     CONF_WIKIPEDIA_ENABLED,
+                    default=False,
+                ): bool,
+                vol.Optional(
+                    CONF_WEB_FETCH_ENABLED,
                     default=False,
                 ): bool,
             }
@@ -889,6 +924,12 @@ class LlmIntentsOptionsFlow(config_entries.OptionsFlowWithReload):
     ) -> config_entries.FlowResult:
         """Handle Wikipedia configuration step in options flow."""
         return await self.handle_step(STEP_WIKIPEDIA, user_input)
+
+    async def async_step_web_fetch(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Handle Web Fetch configuration step in options flow."""
+        return await self.handle_step(STEP_WEB_FETCH, user_input)
 
     async def async_step_configure_basic_utilities(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/llm_intents/config_flow.py
+++ b/custom_components/llm_intents/config_flow.py
@@ -140,7 +140,9 @@ class NullableNumberSelector(NumberSelector):
         return value
 
 
-def get_step_user_data_schema(hass) -> vol.Schema:
+def get_step_user_data_schema(
+    hass: HomeAssistant, args: dict | None = None
+) -> vol.Schema:
     """Generate a static schema for the main menu to select services."""
     schema = {
         vol.Optional(
@@ -174,10 +176,9 @@ def expand_config_for_schema(config: dict) -> dict:
     provider_keys = config.get(CONF_PROVIDER_API_KEYS) or {}
     result[CONF_GOOGLE_API_KEY] = provider_keys.get(PROVIDER_GOOGLE, "")
     result[CONF_BRAVE_API_KEY] = provider_keys.get(PROVIDER_BRAVE, "")
-    result[CONF_WEB_FETCH_MAX_CONTENT_LENGTH] = (
-        config.get(CONF_WEB_FETCH_MAX_CONTENT_LENGTH)
-        or SERVICE_DEFAULTS.get(CONF_WEB_FETCH_MAX_CONTENT_LENGTH)
-    )
+    result[CONF_WEB_FETCH_MAX_CONTENT_LENGTH] = config.get(
+        CONF_WEB_FETCH_MAX_CONTENT_LENGTH,
+    ) or SERVICE_DEFAULTS.get(CONF_WEB_FETCH_MAX_CONTENT_LENGTH)
     return result
 
 
@@ -321,7 +322,8 @@ async def get_brave_schema(
 
 
 async def get_searxng_schema(
-    hass: HomeAssistant, args: dict | None = None
+    hass: HomeAssistant,
+    args: dict | None = None,
 ) -> vol.Schema:
     """Return the static schema for the SearXNG service configuration."""
     return vol.Schema(
@@ -347,7 +349,8 @@ async def get_searxng_schema(
 
 
 async def get_google_places_schema(
-    hass: HomeAssistant, args: dict | None = None
+    hass: HomeAssistant,
+    args: dict | None = None,
 ) -> vol.Schema:
     """Return the static schema for Google Places service configuration."""
     return vol.Schema(
@@ -418,7 +421,8 @@ async def get_google_places_schema(
 
 
 async def get_google_routes_schema(
-    hass: HomeAssistant, args: dict | None = None
+    hass: HomeAssistant,
+    args: dict | None = None,
 ) -> vol.Schema:
     """Return the static schema for Google Routes service configuration."""
     return vol.Schema(
@@ -445,12 +449,13 @@ async def get_google_routes_schema(
                     ),
                 ),
             ),
-        }
+        },
     )
 
 
 async def get_youtube_schema(
-    hass: HomeAssistant, args: dict | None = None
+    hass: HomeAssistant,
+    args: dict | None = None,
 ) -> vol.Schema:
     """Return the static schema for YouTube service configuration."""
     return vol.Schema(
@@ -464,7 +469,8 @@ async def get_youtube_schema(
 
 
 async def get_wikipedia_schema(
-    hass: HomeAssistant, args: dict | None = None
+    hass: HomeAssistant,
+    args: dict | None = None,
 ) -> vol.Schema:
     """Return the static schema for Wikipedia service configuration."""
     return vol.Schema(
@@ -485,7 +491,10 @@ async def get_wikipedia_schema(
     )
 
 
-async def get_web_fetch_schema(hass) -> vol.Schema:
+async def get_web_fetch_schema(
+    hass: HomeAssistant,
+    args: dict | None = None,
+) -> vol.Schema:
     """Return the static schema for Web Fetch service configuration."""
     return vol.Schema(
         {
@@ -499,14 +508,15 @@ async def get_web_fetch_schema(hass) -> vol.Schema:
                     step=500,
                     mode=NumberSelectorMode.BOX,
                     unit_of_measurement="Characters",
-                )
+                ),
             ),
-        }
+        },
     )
 
 
 async def get_basic_utilities_schema(
-    hass: HomeAssistant, args: dict | None = None
+    hass: HomeAssistant,
+    args: dict | None = None,
 ) -> vol.Schema:
     """Return the static schema for Basic Utilities tool configuration."""
     return vol.Schema(
@@ -528,7 +538,8 @@ async def get_basic_utilities_schema(
 
 
 async def get_weather_schema(
-    hass: HomeAssistant, args: dict | None = None
+    hass: HomeAssistant,
+    args: dict | None = None,
 ) -> vol.Schema:
     """Return the static schema for Weather configuration."""
     daily_entities = []
@@ -602,7 +613,7 @@ async def enumerate_tools(hass: HomeAssistant) -> list[llm.Tool]:
         # For simplicity lets just enumerate directly from assist, as otherwise our own internal filtering may get in the way of this
         if api.name == "Assist":
             api_instance = await api.async_get_api_instance(
-                LLMContext(DOMAIN, None, None, None, None)
+                LLMContext(DOMAIN, None, None, None, None),
             )
             tools.extend(api_instance.tools)
 
@@ -610,7 +621,8 @@ async def enumerate_tools(hass: HomeAssistant) -> list[llm.Tool]:
 
 
 async def get_home_control_schema(
-    hass: HomeAssistant, args: dict[str, Any]
+    hass: HomeAssistant,
+    args: dict[str, Any],
 ) -> vol.Schema:
     """Return the static schema for Home Control configuration."""
     return vol.Schema(
@@ -628,9 +640,9 @@ async def get_home_control_schema(
                     options=[tool.name for tool in args.get("tools", [])],
                     multiple=True,
                     mode=SelectSelectorMode.DROPDOWN,
-                )
+                ),
             ),
-        }
+        },
     )
 
 
@@ -812,7 +824,8 @@ class LlmIntentsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.handle_step(STEP_GOOGLE_PLACES, user_input)
 
     async def async_step_google_routes(
-        self, user_input: dict[str, Any] | None = None
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> config_entries.FlowResult:
         """Handle Google Routes configuration step."""
         return await self.handle_step(STEP_GOOGLE_ROUTES, user_input)
@@ -832,7 +845,8 @@ class LlmIntentsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.handle_step(STEP_WIKIPEDIA, user_input)
 
     async def async_step_web_fetch(
-        self, user_input: dict[str, Any] | None = None
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> config_entries.FlowResult:
         """Handle Web Fetch configuration step."""
         return await self.handle_step(STEP_WEB_FETCH, user_input)
@@ -1075,7 +1089,8 @@ class LlmIntentsOptionsFlow(config_entries.OptionsFlowWithReload):
         return await self.handle_step(STEP_GOOGLE_PLACES, user_input)
 
     async def async_step_google_routes(
-        self, user_input: dict[str, Any] | None = None
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> config_entries.FlowResult:
         """Handle Google Routes configuration step in options flow."""
         return await self.handle_step(STEP_GOOGLE_ROUTES, user_input)
@@ -1095,7 +1110,8 @@ class LlmIntentsOptionsFlow(config_entries.OptionsFlowWithReload):
         return await self.handle_step(STEP_WIKIPEDIA, user_input)
 
     async def async_step_web_fetch(
-        self, user_input: dict[str, Any] | None = None
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> config_entries.FlowResult:
         """Handle Web Fetch configuration step in options flow."""
         return await self.handle_step(STEP_WEB_FETCH, user_input)
@@ -1172,9 +1188,12 @@ class LlmIntentsOptionsFlow(config_entries.OptionsFlowWithReload):
         return await self.handle_step(STEP_WEATHER, user_input)
 
     async def async_step_home_control(
-        self, user_input: dict[str, Any] | None = None
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> config_entries.FlowResult:
         """Handle Home Control (override Assist) configuration step in options flow."""
         return await self.handle_step(
-            STEP_HOME_CONTROL, user_input, {"tools": await enumerate_tools(self.hass)}
+            STEP_HOME_CONTROL,
+            user_input,
+            {"tools": await enumerate_tools(self.hass)},
         )

--- a/custom_components/llm_intents/const.py
+++ b/custom_components/llm_intents/const.py
@@ -9,6 +9,7 @@ DOMAIN = "llm_intents"
 ADDON_NAME = "Tools for Assist"
 
 SEARCH_API_NAME = "Search Services"
+WEB_FETCH_API_NAME = "Web Fetch"
 WEATHER_API_NAME = "Weather Forecast"
 MEDIA_API_NAME = "Media Services"
 BASIC_UTILITIES_API_NAME = "Basic Utilities"
@@ -18,6 +19,8 @@ BASIC_UTILITIES_API_NAME = "Basic Utilities"
 CONF_CACHE_MAX_AGE = "cache_max_age"
 
 SEARCH_SERVICES_PROMPT = "You may utilise the Search Services tools to lookup up-to-date information from the internet."
+
+WEB_FETCH_SERVICES_PROMPT = "Use the Web Fetch tool to retrieve the content of web pages and convert HTML to readable text."
 
 WEATHER_SERVICES_PROMPT = """
 Use the Weather Services tools to access current weather and forecast data.
@@ -145,6 +148,11 @@ CONF_YOUTUBE_ENABLED = "youtube_enabled"
 CONF_WIKIPEDIA_ENABLED = "wikipedia_enabled"
 CONF_WIKIPEDIA_NUM_RESULTS = "wikipedia_num_results"
 
+# Web Fetch-specific constants
+
+CONF_WEB_FETCH_ENABLED = "web_fetch_enabled"
+CONF_WEB_FETCH_MAX_CONTENT_LENGTH = "web_fetch_max_content_length"
+
 # Weather constants
 
 CONF_WEATHER_ENABLED = "weather_enabled"
@@ -178,6 +186,7 @@ SERVICE_DEFAULTS = {
     CONF_GOOGLE_PLACES_RADIUS: 5,
     CONF_GOOGLE_PLACES_RANKING: "Distance",
     CONF_WIKIPEDIA_NUM_RESULTS: 1,
+    CONF_WEB_FETCH_MAX_CONTENT_LENGTH: 10000,
     CONF_DAILY_WEATHER_ENTITY: None,
     CONF_HOURLY_WEATHER_ENTITY: None,
     CONF_WEATHER_TEMPERATURE_SENSOR: None,

--- a/custom_components/llm_intents/llm_functions.py
+++ b/custom_components/llm_intents/llm_functions.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_SEARCH_PROVIDER_SEARXNG,
     CONF_UNIT_CONVERTER_ENABLED,
     CONF_WEATHER_ENABLED,
+    CONF_WEB_FETCH_ENABLED,
     CONF_WIKIPEDIA_ENABLED,
     CONF_YOUTUBE_ENABLED,
     DOMAIN,
@@ -37,6 +38,7 @@ from .play_media import PlayVideoTool
 from .searxng_search import SearXngSearchTool
 from .unit_converter import UnitConverterTool
 from .weather import WeatherForecastTool
+from .web_fetch import WebFetchTool
 from .wikipedia import SearchWikipediaTool
 from .youtube import SearchYouTubeTool
 
@@ -58,6 +60,7 @@ SEARCH_CONF_ENABLED_MAP = [
     (CONF_GOOGLE_PLACES_ENABLED, FindPlacesTool),
     (CONF_YOUTUBE_ENABLED, SearchYouTubeTool),
     (CONF_WIKIPEDIA_ENABLED, SearchWikipediaTool),
+    (CONF_WEB_FETCH_ENABLED, WebFetchTool),
 ]
 
 WEATHER_CONF_ENABLED_MAP = [

--- a/custom_components/llm_intents/searxng_search.py
+++ b/custom_components/llm_intents/searxng_search.py
@@ -42,9 +42,11 @@ class SearXngSearchTool(SearchWebTool):
                 results = []
                 for result in data.get("results", [])[0:num_results]:
                     title = result.get("title", "")
+                    result_url = result.get("url", "")
                     content = await self.cleanup_text(result.get("content", ""))
 
-                    item = {"title": title, "content": content}
+                    item = {"title": title, "url": result_url, "content": content}
+
                     results.append(item)
                 return results
             err_msg = (

--- a/custom_components/llm_intents/translations/en.json
+++ b/custom_components/llm_intents/translations/en.json
@@ -9,6 +9,7 @@
           "google_places_enabled": "Enable Google Places",
           "youtube_enabled": "Enable YouTube Search",
           "wikipedia_enabled": "Enable Wikipedia Search",
+          "web_fetch_enabled": "Enable Web Fetch",
           "weather_enabled": "Enable Weather Forecast",
           "basic_utilities_enabled": "Enable Basic Utilities"
         }
@@ -80,6 +81,13 @@
           "wikipedia_num_results": "Number of Results"
         }
       },
+      "web_fetch": {
+        "title": "Configure Web Fetch",
+        "description": "Configure Web Fetch settings.",
+        "data": {
+          "web_fetch_max_content_length": "Maximum Content Length"
+        }
+      },
       "weather": {
         "title": "Configure Weather",
         "description": "Configure Weather sources.",
@@ -126,7 +134,8 @@
           "search_provider": "Web Search Provider",
           "google_places_enabled": "Enable Google Places",
           "youtube_enabled": "Enable YouTube Search",
-          "wikipedia_enabled": "Enable Wikipedia Search"
+          "wikipedia_enabled": "Enable Wikipedia Search",
+          "web_fetch_enabled": "Enable Web Fetch"
         }
       },
       "configure_weather": {

--- a/custom_components/llm_intents/translations/ru.json
+++ b/custom_components/llm_intents/translations/ru.json
@@ -1,0 +1,254 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Настройка Tools for Assist",
+        "description": "Выберите сервисы, которые вы хотите включить.",
+        "data": {
+          "search_provider": "Поисковый провайдер",
+          "google_places_enabled": "Включить Google Places",
+          "youtube_enabled": "Включить поиск по YouTube",
+          "wikipedia_enabled": "Включить поиск по Wikipedia",
+          "web_fetch_enabled": "Включить парсинг веб-страниц",
+          "weather_enabled": "Включить прогноз погоды",
+          "basic_utilities_enabled": "Включить базовые утилиты"
+        }
+      },
+      "brave": {
+        "title": "Настройка Brave Web Search",
+        "description": "Настройка параметров Brave Web Search API.",
+        "data": {
+          "brave_api_key": "Ключ API",
+          "brave_num_results": "Количество результатов",
+          "brave_country_code": "Код страны (необязательно)",
+          "brave_latitude": "Широта (необязательно)",
+          "brave_longitude": "Долгота (необязательно)",
+          "brave_timezone": "Часовой пояс (необязательно)",
+          "brave_post_code": "Почтовый индекс (необязательно)",
+          "brave_max_snippets_per_url": "Макс. фрагментов на результат"
+        }
+      },
+      "brave_llm": {
+        "title": "Настройка Brave LLM Context Search",
+        "description": "Настройка параметров Brave LLM Context API.",
+        "data": {
+          "brave_api_key": "Ключ API",
+          "brave_num_results": "Количество результатов",
+          "brave_country_code": "Код страны (необязательно)",
+          "brave_latitude": "Широта (необязательно)",
+          "brave_longitude": "Долгота (необязательно)",
+          "brave_timezone": "Часовой пояс (необязательно)",
+          "brave_post_code": "Почтовый индекс (необязательно)",
+          "brave_max_snippets_per_url": "Макс. фрагментов на результат",
+          "brave_max_tokens_per_url": "Макс. токенов на результат",
+          "brave_context_threshold_mode": "Режим порогового значения контекста"
+        }
+      },
+      "searxng": {
+        "title": "Настройка SearXNG Web Search",
+        "description": "Настройка параметров SearXNG Web Search API.",
+        "data": {
+          "searxng_server_url": "URL сервера",
+          "searxng_num_results": "Количество результатов"
+        },
+        "data_description": {
+          "searxng_server_url": "Протокол, хост и порт, например: http://localhost:8080"
+        }
+      },
+      "google_places": {
+        "title": "Настройка Google Places",
+        "description": "Настройка параметров Google Places API.",
+        "data": {
+          "google_api_key": "Ключ Google API",
+          "google_places_rank_preference": "Предпочтение ранжированию",
+          "google_places_num_results": "Количество результатов",
+          "google_places_latitude": "Широта смещения (необязательно)",
+          "google_places_longitude": "Долгота смещения (необязательно)",
+          "google_places_radius": "Радиус смещения (км)"
+        }
+      },
+      "youtube": {
+        "title": "Настройка поиска по YouTube",
+        "description": "Настройка поиска по YouTube. Использует тот же ключ Google API, что и Google Places.",
+        "data": {
+          "google_api_key": "Ключ Google API"
+        }
+      },
+      "wikipedia": {
+        "title": "Настройка Wikipedia",
+        "description": "Настройка поиска по Wikipedia.",
+        "data": {
+          "wikipedia_num_results": "Количество результатов"
+        }
+      },
+      "web_fetch": {
+        "title": "Настройка Web Fetch",
+        "description": "Настройка параметров парсинга веб-страниц.",
+        "data": {
+          "web_fetch_max_content_length": "Максимальная длина контента"
+        }
+      },
+      "weather": {
+        "title": "Настройка погоды",
+        "description": "Настройка источников погоды.",
+        "data": {
+          "weather_daily_entity": "Сущность дневного прогноза",
+          "weather_hourly_entity": "Сущность почасового прогноза",
+          "current_temperature_entity": "Датчик текущей температуры"
+        },
+        "data_description": {
+          "weather_daily_entity": "Сущность погоды для получения данных дневного прогноза",
+          "weather_hourly_entity": "Сущность погоды для почасового прогноза (необязательно)",
+          "current_temperature_entity": "Датчик для текущей температуры (необязательно)"
+        }
+      },
+      "basic_utilities": {
+        "title": "Настройка базовых утилит",
+        "description": "Выберите, какие базовые утилиты включить.",
+        "data": {
+          "calculator_enabled": "Включить калькулятор",
+          "unit_converter_enabled": "Включить конвертер единиц",
+          "date_info_enabled": "Включить информацию о дате"
+        }
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Допускается только один экземпляр Tools for Assist"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Опции Tools for Assist",
+        "description": "Выберите, что вы хотите сделать:",
+        "menu_options": {
+          "configure": "Настроить поисковые сервисы",
+          "configure_weather": "Настроить прогноз погоды",
+          "configure_basic_utilities": "Настроить базовые утилиты"
+        }
+      },
+      "configure": {
+        "title": "Настройка поисковых сервисов",
+        "description": "Выберите сервисы, которые вы хотите использовать.",
+        "data": {
+          "search_provider": "Поисковый провайдер",
+          "google_places_enabled": "Включить Google Places",
+          "youtube_enabled": "Включить поиск по YouTube",
+          "wikipedia_enabled": "Включить поиск по Wikipedia",
+          "web_fetch_enabled": "Включить парсинг веб-страниц"
+        }
+      },
+      "configure_weather": {
+        "title": "Настройка прогноза погоды",
+        "description": "Выберите сервисы, которые вы хотите использовать.",
+        "data": {
+          "weather_enabled": "Включить прогноз погоды"
+        }
+      },
+      "brave": {
+        "title": "Настройка Brave Web Search",
+        "description": "Настройка параметров Brave Web Search API.",
+        "data": {
+          "brave_api_key": "Ключ API",
+          "brave_num_results": "Количество результатов",
+          "brave_country_code": "Код страны (необязательно)",
+          "brave_latitude": "Широта (необязательно)",
+          "brave_longitude": "Долгота (необязательно)",
+          "brave_timezone": "Часовой пояс (необязательно)",
+          "brave_post_code": "Почтовый индекс (необязательно)",
+          "brave_max_snippets_per_url": "Макс. фрагментов на результат"
+        }
+      },
+      "brave_llm": {
+        "title": "Настройка Brave LLM Context Search",
+        "description": "Настройка параметров Brave LLM Context API.",
+        "data": {
+          "brave_api_key": "Ключ API",
+          "brave_num_results": "Количество результатов",
+          "brave_country_code": "Код страны (необязательно)",
+          "brave_latitude": "Широта (необязательно)",
+          "brave_longitude": "Долгота (необязательно)",
+          "brave_timezone": "Часовой пояс (необязательно)",
+          "brave_post_code": "Почтовый индекс (необязательно)",
+          "brave_max_snippets_per_url": "Макс. фрагментов на результат",
+          "brave_max_tokens_per_url": "Макс. токенов на результат",
+          "brave_context_threshold_mode": "Режим порогового значения контекста"
+        }
+      },
+      "searxng": {
+        "title": "Настройка SearXNG Web Search",
+        "description": "Настройка параметров SearXNG Web Search API.",
+        "data": {
+          "searxng_server_url": "URL сервера",
+          "searxng_num_results": "Количество результатов"
+        },
+        "data_description": {
+          "searxng_server_url": "Протокол, хост и порт, например: http://localhost:8080"
+        }
+      },
+      "google_places": {
+        "title": "Настройка Google Places",
+        "description": "Настройка параметров Google Places API.",
+        "data": {
+          "google_api_key": "Ключ Google API",
+          "google_places_rank_preference": "Предпочтение ранжированию",
+          "google_places_num_results": "Количество результатов",
+          "google_places_latitude": "Широта смещения (необязательно)",
+          "google_places_longitude": "Долгота смещения (необязательно)",
+          "google_places_radius": "Радиус смещения (км)"
+        }
+      },
+      "youtube": {
+        "title": "Настройка поиска по YouTube",
+        "description": "Настройка поиска по YouTube. Использует тот же ключ Google API, что и Google Places.",
+        "data": {
+          "google_api_key": "Ключ Google API"
+        }
+      },
+      "wikipedia": {
+        "title": "Настройка Wikipedia",
+        "description": "Настройка поиска по Wikipedia.",
+        "data": {
+          "wikipedia_num_results": "Количество результатов"
+        }
+      },
+      "web_fetch": {
+        "title": "Настройка парсинга веб-страниц",
+        "description": "Настройка параметров парсинга веб-страниц.",
+        "data": {
+          "web_fetch_max_content_length": "Максимальная длина контента"
+        }
+      },
+      "weather": {
+        "title": "Настройка погоды",
+        "description": "Настройка источников погоды.",
+        "data": {
+          "weather_daily_entity": "Сущность дневного прогноза",
+          "weather_hourly_entity": "Сущность почасового прогноза",
+          "current_temperature_entity": "Датчик текущей температуры"
+        },
+        "data_description": {
+          "weather_daily_entity": "Сущность погоды для получения данных дневного прогноза",
+          "weather_hourly_entity": "Сущность погоды для почасового прогноза (необязательно)",
+          "current_temperature_entity": "Датчик для текущей температуры (необязательно)"
+        }
+      },
+      "configure_basic_utilities": {
+        "title": "Настройка базовых утилит",
+        "description": "Включение или отключение базовых утилит.",
+        "data": {
+          "basic_utilities_enabled": "Включить базовые утилиты"
+        }
+      },
+      "basic_utilities": {
+        "title": "Настройка базовых утилит",
+        "description": "Выберите, какие базовые утилиты включить.",
+        "data": {
+          "calculator_enabled": "Включить калькулятор",
+          "unit_converter_enabled": "Включить конвертер единиц",
+          "date_info_enabled": "Включить информацию о дате"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/llm_intents/web_fetch.py
+++ b/custom_components/llm_intents/web_fetch.py
@@ -1,0 +1,210 @@
+"""Web Fetch tool for retrieving and extracting content from web pages."""
+
+import logging
+import re
+from html.parser import HTMLParser
+from typing import ClassVar
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.json import JsonObjectType
+
+from .base_tool import BaseTool
+from .cache import SQLiteCache
+from .const import (
+    CONF_WEB_FETCH_MAX_CONTENT_LENGTH,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HTMLToText(HTMLParser):
+    """Convert HTML content to plain text."""
+
+    # Tags whose text content should be preceded by a newline
+    _block_tags: ClassVar[set[str]] = {
+        "div",
+        "p",
+        "li",
+        "ul",
+        "ol",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "table",
+        "tr",
+        "td",
+        "th",
+        "blockquote",
+        "pre",
+        "section",
+        "article",
+        "header",
+        "footer",
+        "nav",
+        "main",
+        "aside",
+        "figure",
+        "figcaption",
+    }
+
+    # Tags to skip entirely (content not useful for reading)
+    _skip_tags: ClassVar[set[str]] = {"script", "style", "noscript"}
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._result: list[str] = []
+        self._skipping = False
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in self._skip_tags:
+            self._skipping = True
+            self._skip_depth += 1
+        elif tag in self._block_tags:
+            if self._result and self._result[-1] != "\n":
+                self._result.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._skipping and tag in self._skip_tags:
+            self._skip_depth -= 1
+            if self._skip_depth <= 0:
+                self._skipping = False
+                self._skip_depth = 0
+
+    def handle_data(self, data: str) -> None:
+        if not self._skipping:
+            text = data.strip()
+            if text:
+                self._result.append(text)
+
+    def get_text(self) -> str:
+        return " ".join(self._result)
+
+
+def html_to_text(html_content: str) -> str:
+    """Convert HTML content to readable plain text."""
+    parser = HTMLToText()
+    parser.feed(html_content)
+    return parser.get_text()
+
+
+class WebFetchTool(BaseTool):
+    """Tool for fetching and extracting text content from web pages."""
+
+    name = "web_fetch"
+    description = (
+        "Fetches the content of a web page at the given URL and returns "
+        "the readable text. Use this to read articles, documentation, "
+        "blog posts, or any other web page content."
+    )
+    prompt_description = None
+
+    parameters = vol.Schema(
+        {
+            vol.Required(
+                "url",
+                description="The full URL of the web page to fetch (e.g. https://example.com/article)",
+            ): str,
+        }
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Call the tool."""
+        config_data = hass.data[DOMAIN].get("config", {})
+        entry = next(iter(hass.config_entries.async_entries(DOMAIN)))
+        config_data = {**config_data, **entry.options}
+
+        url = tool_input.tool_args["url"]
+        max_length = int(config_data.get(CONF_WEB_FETCH_MAX_CONTENT_LENGTH, 10000))
+
+        _LOGGER.info("Web fetch requested for: %s", url)
+
+        # Validate URL scheme
+        if not url.startswith(("http://", "https://")):
+            return {
+                "error": f"Invalid URL scheme. Only HTTP and HTTPS are supported: {url}"
+            }
+
+        cache = SQLiteCache()
+        cached_response = cache.get(__name__, {"url": url})
+        if cached_response:
+            return cached_response
+
+        try:
+            session = async_get_clientsession(hass)
+
+            headers = {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/125.0.0.0 Safari/537.36"
+                ),
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+            }
+
+            async with session.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    _LOGGER.error(
+                        "Web fetch received HTTP %s for URL: %s", resp.status, url
+                    )
+                    return {
+                        "error": f"Failed to fetch page. HTTP status: {resp.status}",
+                        "url": url,
+                    }
+
+                content_type = resp.headers.get("Content-Type", "")
+                if (
+                    "text/html" not in content_type
+                    and "application/xhtml" not in content_type
+                ):
+                    # For non-HTML content, return as-is (e.g., plain text, markdown)
+                    text_content = await resp.text()
+                else:
+                    html_content = await resp.text()
+                    text_content = html_to_text(html_content)
+
+                # Clean up extra whitespace
+                text_content = re.sub(r"\s{2,}", " ", text_content).strip()
+
+                if not text_content:
+                    return {
+                        "result": f"No readable text content found at {url}",
+                        "url": url,
+                    }
+
+                # Truncate if too long
+                if len(text_content) > max_length:
+                    truncated_chars = len(text_content) - max_length
+                    text_content = text_content[:max_length]
+                    text_content += (
+                        f"\n\n... [truncated, {truncated_chars} characters omitted]"
+                    )
+
+                result = {
+                    "url": url,
+                    "content": text_content,
+                    "content_length": len(text_content),
+                }
+
+                cache.set(__name__, {"url": url}, result)
+                return result
+
+        except TimeoutError:
+            _LOGGER.exception("Web fetch timeout for URL: %s", url)
+            return {"error": f"Request timed out fetching: {url}", "url": url}
+        except Exception as e:
+            _LOGGER.exception("Web fetch error for URL %s", url)
+            return {"error": f"Error fetching page: {e!s}", "url": url}

--- a/custom_components/llm_intents/web_fetch.py
+++ b/custom_components/llm_intents/web_fetch.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from html.parser import HTMLParser
+from http import HTTPStatus
 from typing import ClassVar
 
 import voluptuous as vol
@@ -156,7 +157,7 @@ class WebFetchTool(BaseTool):
             }
 
             async with session.get(url, headers=headers) as resp:
-                if resp.status != 200:
+                if resp.status != HTTPStatus.OK:
                     _LOGGER.error(
                         "Web fetch received HTTP %s for URL: %s", resp.status, url
                     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Test configuration for LLM Intents integration."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
@@ -158,3 +158,21 @@ def wikipedia_summary_result() -> dict:
         "extract": "This is a test summary of the Wikipedia article.",
         "title": "Test Article",
     }
+
+
+@pytest.fixture(autouse=True)
+def mock_sqlite_cache() -> None:
+    """Default: patch SQLiteCache so we don't create a real DB  file."""
+    with (
+        patch(
+            "custom_components.llm_intents.web_fetch.SQLiteCache._init_db",
+        ),
+        patch(
+            "custom_components.llm_intents.web_fetch.SQLiteCache.set",
+        ),
+        patch(
+            "custom_components.llm_intents.web_fetch.SQLiteCache.get",
+            return_value=None,
+        ),
+    ):
+        yield

--- a/tests/test_web_fetch.py
+++ b/tests/test_web_fetch.py
@@ -1,0 +1,403 @@
+"""Tests for the Web Fetch tool."""
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from aiohttp import ClientSession
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
+
+from custom_components.llm_intents.const import (
+    CONF_WEB_FETCH_MAX_CONTENT_LENGTH,
+    DOMAIN,
+)
+from custom_components.llm_intents.web_fetch import (
+    HTMLToText,
+    WebFetchTool,
+    html_to_text,
+)
+
+from .utils import MockContext
+
+PATCH_CLIENT_SESSION_PATH = (
+    "custom_components.llm_intents.web_fetch.async_get_clientsession"
+)
+
+
+# ---------------------------------------------------------------------------
+# HTTP response/session helpers (text-based, not JSON-based)
+# ---------------------------------------------------------------------------
+
+
+def mock_text_response(
+    status: int, text: str, content_type: str = "text/html"
+) -> AsyncMock:
+    """Mock HTTP response that returns text content (no JSON)."""
+    response = AsyncMock()
+    response.status = status
+    response.text = AsyncMock(return_value=text)
+    response.headers = {"Content-Type": content_type}
+    return response
+
+
+def mock_text_session(
+    status: int, text: str, content_type: str = "text/html"
+) -> ClientSession:
+    """Mock aiohttp ClientSession returning a text response."""
+    session = AsyncMock()
+
+    def mock_get(*args: object, **kwargs: object) -> MockContext:
+        return MockContext(mock_text_response(status, text, content_type))
+
+    session.get = Mock(side_effect=mock_get)
+    return session
+
+
+def mock_error_session(error: Exception) -> ClientSession:
+    """Mock aiohttp ClientSession whose GET call raises an exception."""
+    session = AsyncMock()
+    session.get = Mock(side_effect=error)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config() -> dict[str, int]:
+    """Default tool config."""
+    return {CONF_WEB_FETCH_MAX_CONTENT_LENGTH: 10000}
+
+
+@pytest.fixture
+def small_max_config() -> dict[str, int]:
+    """Config with a tiny content limit for truncation tests."""
+    return {CONF_WEB_FETCH_MAX_CONTENT_LENGTH: 50}
+
+
+@pytest.fixture
+def tool(config: dict[str, int], mock_hass: HomeAssistant) -> WebFetchTool:
+    """Create a WebFetchTool with a mocked HomeAssistant."""
+    mock_hass.data = {DOMAIN: {"config": config}}
+    entry = MagicMock()
+    entry.options = {}
+    mock_hass.config_entries.async_entries.return_value = [entry]
+    return WebFetchTool(config, mock_hass)
+
+
+@pytest.fixture
+def tool_small_max(
+    small_max_config: dict[str, int], mock_hass: HomeAssistant
+) -> WebFetchTool:
+    """WebFetchTool with a small max content length."""
+    mock_hass.data = {DOMAIN: {"config": small_max_config}}
+    entry = MagicMock()
+    entry.options = {}
+    mock_hass.config_entries.async_entries.return_value = [entry]
+    return WebFetchTool(small_max_config, mock_hass)
+
+
+@pytest.fixture
+def tool_input() -> llm.ToolInput:
+    """Mock ToolInput for web_fetch."""
+    ti = MagicMock(spec=llm.ToolInput)
+    ti.tool_args = {"url": "https://example.com"}
+    return ti
+
+
+@pytest.fixture
+def llm_context() -> llm.LLMContext:
+    """Mock LLMContext."""
+    return MagicMock(spec=llm.LLMContext)
+
+
+# ---------------------------------------------------------------------------
+# URL validation
+# ---------------------------------------------------------------------------
+
+
+async def test_web_fetch_invalid_scheme(
+    tool: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """Non-http/https URLs should return an error."""
+    tool_input.tool_args = {"url": "ftp://example.com/file"}
+
+    result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert "error" in result
+    assert "Invalid URL scheme" in result["error"]
+
+
+async def test_web_fetch_invalid_scheme_empty(
+    tool: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """Empty string URL should return an error."""
+    tool_input.tool_args = {"url": ""}
+
+    result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert "error" in result
+    assert "Invalid URL scheme" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Successful fetches
+# ---------------------------------------------------------------------------
+
+
+async def test_web_fetch_html_success(
+    tool: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """HTML content should be converted to plain text."""
+    html = "<html><body><p>Hello World</p><p>Second paragraph</p></body></html>"
+    session = mock_text_session(200, html)
+
+    with (
+        patch(
+            PATCH_CLIENT_SESSION_PATH,
+            return_value=session,
+        ),
+        patch("custom_components.llm_intents.web_fetch.SQLiteCache.set") as mock_set,
+    ):
+        result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert result["url"] == "https://example.com"
+    assert "Hello World" in result["content"]
+    assert "Second paragraph" in result["content"]
+    assert result["content_length"] > 0
+    assert mock_set.called
+
+
+async def test_web_fetch_non_html_success(
+    tool: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """Non-HTML content (e.g. text/plain) should be returned as-is."""
+    text = "This is plain text content."
+    session = mock_text_session(200, text, content_type="text/plain")
+
+    with patch(
+        PATCH_CLIENT_SESSION_PATH,
+        return_value=session,
+    ):
+        result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert result["content"] == "This is plain text content."
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+async def test_web_fetch_http_error(
+    tool: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """Non-200 HTTP status should return an error message."""
+    session = mock_text_session(404, "Not Found")
+
+    with patch(
+        PATCH_CLIENT_SESSION_PATH,
+        return_value=session,
+    ):
+        result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert "error" in result
+    assert "HTTP status: 404" in result["error"]
+    assert result["url"] == "https://example.com"
+
+
+async def test_web_fetch_timeout(
+    tool: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """TimeoutError should be caught and returned as error dict."""
+    session = mock_error_session(TimeoutError("timed out"))
+
+    with patch(
+        PATCH_CLIENT_SESSION_PATH,
+        return_value=session,
+    ):
+        result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert "error" in result
+    assert "timed out" in result["error"].lower()
+    assert result["url"] == "https://example.com"
+
+
+async def test_web_fetch_generic_exception(
+    tool: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """Generic exceptions should be caught and returned as error dict."""
+    session = mock_error_session(ConnectionError("Connection refused"))
+
+    with patch(
+        PATCH_CLIENT_SESSION_PATH,
+        return_value=session,
+    ):
+        result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert "error" in result
+    assert "Error fetching page" in result["error"]
+    assert result["url"] == "https://example.com"
+
+
+async def test_web_fetch_empty_content(
+    tool: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """Pages with no readable text should return a 'no content' result."""
+    html = "<html><body><script>var x = 1;</script><style>.cls{}</style></body></html>"
+    session = mock_text_session(200, html)
+
+    with patch(
+        PATCH_CLIENT_SESSION_PATH,
+        return_value=session,
+    ):
+        result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert "result" in result
+    assert "No readable text content found" in result["result"]
+    assert result["url"] == "https://example.com"
+
+
+# ---------------------------------------------------------------------------
+# Truncation
+# ---------------------------------------------------------------------------
+
+
+async def test_web_fetch_truncation(
+    tool_small_max: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """Content exceeding max_length should be truncated with a notice."""
+    long_text = "word " * 200
+    session = mock_text_session(200, long_text)
+
+    with patch(
+        PATCH_CLIENT_SESSION_PATH,
+        return_value=session,
+    ):
+        result = await tool_small_max.async_call(
+            tool_small_max.hass, tool_input, llm_context
+        )
+
+    assert "[truncated" in result["content"]
+    assert result["content_length"] <= 50 + 45  # 50 max + truncation suffix
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+async def test_web_fetch_cache_hit(
+    tool: WebFetchTool, tool_input: llm.ToolInput, llm_context: llm.LLMContext
+) -> None:
+    """Cached results should be returned without making an HTTP request."""
+    cached = {
+        "url": "https://example.com",
+        "content": "Cached content",
+        "content_length": 14,
+    }
+
+    with (
+        patch(
+            PATCH_CLIENT_SESSION_PATH,
+        ) as mock_session_fn,
+        patch(
+            "custom_components.llm_intents.web_fetch.SQLiteCache.get",
+            return_value=cached,
+        ),
+    ):
+        result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert result == cached
+    mock_session_fn.assert_not_called()
+
+
+async def test_web_fetch_cache_miss_fetches_and_stores(
+    tool: WebFetchTool,
+    tool_input: llm.ToolInput,
+    llm_context: llm.LLMContext,
+) -> None:
+    """A cache miss should fetch the page and store the result."""
+    session = mock_text_session(200, "<p>fresh content</p>")
+
+    with (
+        patch(
+            PATCH_CLIENT_SESSION_PATH,
+            return_value=session,
+        ),
+        patch(
+            "custom_components.llm_intents.web_fetch.SQLiteCache.set",
+        ) as mock_set,
+    ):
+        result = await tool.async_call(tool.hass, tool_input, llm_context)
+
+    assert result["content"] == "fresh content"
+    mock_set.assert_called_once()
+    args, _ = mock_set.call_args
+    assert args[0] == "custom_components.llm_intents.web_fetch"
+    assert args[1] == {"url": "https://example.com"}
+
+
+# ---------------------------------------------------------------------------
+# HTMLToText parser unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHTMLToText:
+    """Unit tests for the HTMLToText parser."""
+
+    def test_strips_tags(self) -> None:
+        """Basic HTML tags should be stripped, text preserved."""
+        result = html_to_text("<b>bold</b> and <i>italic</i>")
+        assert "bold" in result
+        assert "italic" in result
+
+    def test_skips_script_style(self) -> None:
+        """Content inside script/style/noscript tags should be omitted."""
+        html = (
+            "<p>visible</p><script>var x=1;</script>"
+            "<style>.c{}</style><p>also visible</p>"
+        )
+        result = html_to_text(html)
+        assert "visible" in result
+        assert "also visible" in result
+        assert "var x" not in result
+        assert ".c{}" not in result
+
+    def test_block_tags_separate_content(self) -> None:
+        """Block-level tags should introduce separation between text blocks."""
+        html = "<p>First</p><p>Second</p>"
+        result = html_to_text(html)
+        assert "First" in result
+        assert "Second" in result
+
+    def test_empty_input(self) -> None:
+        """Empty string should produce empty output."""
+        assert html_to_text("") == ""
+
+    def test_no_readable_text(self) -> None:
+        """Pages with only script/style content yield empty string."""
+        html = "<html><script>a</script><style>b</style></html>"
+        assert html_to_text(html) == ""
+
+    def test_nested_skip_tags(self) -> None:
+        """Nested script/style tags should be handled (depth tracking)."""
+        html = "<div>ok</div><script>if(1){<script>2</script>}</script><p>visible</p>"
+        result = html_to_text(html)
+        assert "ok" in result
+        assert "visible" in result
+
+    def test_whitespace_handling(self) -> None:
+        """Whitespace in data content should be collapsed."""
+        html = "<div>  spaced   out  </div>"
+        result = html_to_text(html)
+        assert "spaced" in result
+
+    def test_parser_class_directly(self) -> None:
+        """Test the HTMLToText class directly."""
+        parser = HTMLToText()
+        parser.feed("<p>Hello</p>")
+        result = parser.get_text()
+        assert "Hello" in result


### PR DESCRIPTION
## Summary
- Add **Web Fetch** tool — fetches web page content, converts HTML to readable text, with configurable max content length and SQLite caching
- Return **URL** in search results (Brave + SearXNG) so the LLM can pass links to Web Fetch for full-page reading
- Update `SEARCH_SERVICES_PROMPT` to guide the LLM to use Web Fetch when search results contain relevant URLs
- Add **Russian translation** (`ru.json`) for all config flow strings

## Test plan
- [x] Install integration, enable Web Fetch in config flow
- [x] Verify checkboxes show translated labels (EN + RU)
- [x] Web Fetch fetches a URL, returns plain text content
- [x] Search results include URL field for follow-up fetching
- [x] Config flow options screen shows Web Fetch toggle