### PR TITLE
Adjust precipitation chance categorization logic

### DIFF
--- a/custom_components/llm_intents/weather.py
+++ b/custom_components/llm_intents/weather.py
@@ -55,7 +55,7 @@ def _friendly_precipitation_chance(precipitation_chance: int) -> str:
         if precipitation_chance <= 15
         else "possible"
         if precipitation_chance <= 30
-        else "moderate"
+        else "probable"
         if precipitation_chance <= 50
         else "likely"
         if precipitation_chance <= 70

--- a/custom_components/llm_intents/weather.py
+++ b/custom_components/llm_intents/weather.py
@@ -55,7 +55,7 @@ def _friendly_precipitation_chance(precipitation_chance: int) -> str:
         if precipitation_chance <= 15
         else "possible"
         if precipitation_chance <= 30
-        else "probable"
+        else "moderate"
         if precipitation_chance <= 50
         else "likely"
         if precipitation_chance <= 70
@@ -222,7 +222,7 @@ class WeatherForecastTool(BaseTool):
             WeatherAttribute(key="condition", name="General Condition", formatter=None),
             WeatherAttribute(
                 key="precipitation_probability",
-                name="Precipitation",
+                name="Chance of Precipitation",
                 formatter=_friendly_precipitation_chance,
             ),
         ]
@@ -272,7 +272,7 @@ class WeatherForecastTool(BaseTool):
             WeatherAttribute(key="condition", name="General Condition", formatter=None),
             WeatherAttribute(
                 key="precipitation_probability",
-                name="Precipitation",
+                name="Chance of Precipitation",
                 formatter=_friendly_precipitation_chance,
             ),
         ]
@@ -336,7 +336,7 @@ class WeatherForecastTool(BaseTool):
         hourly_attributes = [
             WeatherAttribute(name="General Condition", key="condition", formatter=None),
             WeatherAttribute(
-                name="Precipitation",
+                name="Chance of Precipitation",
                 key="precipitation_probability",
                 formatter=_friendly_precipitation_chance,
             ),


### PR DESCRIPTION
We have started having more rain and I have noticed that whenever the chance is `moderate` the LLM treats this as a precipitation amount as opposed to chance. So it states it as `there will be a moderate about of rain` vs `there is a moderate chance of rain`. This could also be fixed by making the field say `Chance` in the tool response but it understands all of the others as probability so this seems like the easiest tweak.