### PR TITLE
feat: add Tavily as configurable web search provider

### DIFF
--- a/custom_components/llm_intents/config_flow.py
+++ b/custom_components/llm_intents/config_flow.py
@@ -64,9 +64,12 @@ from .const import (
     CONF_SEARCH_PROVIDER_BRAVE,
     CONF_SEARCH_PROVIDER_BRAVE_LLM,
     CONF_SEARCH_PROVIDER_SEARXNG,
+    CONF_SEARCH_PROVIDER_TAVILY,
     CONF_SEARCH_PROVIDERS,
     CONF_SEARXNG_NUM_RESULTS,
     CONF_SEARXNG_URL,
+    CONF_TAVILY_API_KEY,
+    CONF_TAVILY_NUM_RESULTS,
     CONF_UNIT_CONVERTER_ENABLED,
     CONF_WEATHER_ENABLED,
     CONF_WEATHER_TEMPERATURE_SENSOR,
@@ -76,6 +79,7 @@ from .const import (
     DOMAIN,
     PROVIDER_BRAVE,
     PROVIDER_GOOGLE,
+    PROVIDER_TAVILY,
     SERVICE_DEFAULTS,
 )
 
@@ -90,6 +94,7 @@ STEP_USER = "user"
 STEP_BRAVE = "brave"
 STEP_BRAVE_LLM = "brave_llm"
 STEP_SEARXNG = "searxng"
+STEP_TAVILY = "tavily"
 STEP_GOOGLE_PLACES = "google_places"
 STEP_YOUTUBE = "youtube"
 STEP_WIKIPEDIA = "wikipedia"
@@ -153,6 +158,7 @@ def expand_config_for_schema(config: dict) -> dict:
     provider_keys = config.get(CONF_PROVIDER_API_KEYS) or {}
     result[CONF_GOOGLE_API_KEY] = provider_keys.get(PROVIDER_GOOGLE, "")
     result[CONF_BRAVE_API_KEY] = provider_keys.get(PROVIDER_BRAVE, "")
+    result[CONF_TAVILY_API_KEY] = provider_keys.get(PROVIDER_TAVILY, "")
     return result
 
 
@@ -164,6 +170,8 @@ def merge_provider_api_keys_from_input(config_data: dict, user_input: dict) -> N
         provider_keys[PROVIDER_BRAVE] = user_input[CONF_BRAVE_API_KEY]
     if CONF_GOOGLE_API_KEY in user_input:
         provider_keys[PROVIDER_GOOGLE] = user_input[CONF_GOOGLE_API_KEY]
+    if CONF_TAVILY_API_KEY in user_input:
+        provider_keys[PROVIDER_TAVILY] = user_input[CONF_TAVILY_API_KEY]
 
     if PROVIDER_BRAVE not in provider_keys and config_data.get(CONF_BRAVE_API_KEY):
         provider_keys[PROVIDER_BRAVE] = config_data[CONF_BRAVE_API_KEY]
@@ -178,6 +186,7 @@ def merge_provider_api_keys_from_input(config_data: dict, user_input: dict) -> N
     config_data.pop(CONF_BRAVE_API_KEY, None)
     config_data.pop(CONF_GOOGLE_API_KEY, None)
     config_data.pop(CONF_GOOGLE_PLACES_API_KEY, None)
+    config_data.pop(CONF_TAVILY_API_KEY, None)
 
 
 async def get_brave_schema(
@@ -306,6 +315,33 @@ async def get_searxng_schema(hass: HomeAssistant) -> vol.Schema:
             vol.Required(
                 CONF_SEARXNG_NUM_RESULTS,
                 default=SERVICE_DEFAULTS.get(CONF_SEARXNG_NUM_RESULTS),
+            ): NumberSelector(
+                NumberSelectorConfig(
+                    min=1,
+                    max=20,
+                    step=1,
+                    mode=NumberSelectorMode.SLIDER,
+                    unit_of_measurement="Results",
+                ),
+            ),
+        },
+    )
+
+
+async def get_tavily_schema(
+    hass: HomeAssistant,
+    args: dict | None = None,
+) -> vol.Schema:
+    """Return the static schema for Tavily service configuration."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_TAVILY_API_KEY,
+                default=SERVICE_DEFAULTS.get(CONF_TAVILY_API_KEY),
+            ): str,
+            vol.Required(
+                CONF_TAVILY_NUM_RESULTS,
+                default=SERVICE_DEFAULTS.get(CONF_TAVILY_NUM_RESULTS),
             ): NumberSelector(
                 NumberSelectorConfig(
                     min=1,
@@ -519,6 +555,10 @@ SEARCH_STEP_ORDER = {
         lambda data: data.get(CONF_SEARCH_PROVIDER) == CONF_SEARCH_PROVIDER_SEARXNG,
         get_searxng_schema,
     ],
+    STEP_TAVILY: [
+        lambda data: data.get(CONF_SEARCH_PROVIDER) == CONF_SEARCH_PROVIDER_TAVILY,
+        get_tavily_schema,
+    ],
     STEP_GOOGLE_PLACES: [CONF_GOOGLE_PLACES_ENABLED, get_google_places_schema],
     STEP_YOUTUBE: [CONF_YOUTUBE_ENABLED, get_youtube_schema],
     STEP_WIKIPEDIA: [CONF_WIKIPEDIA_ENABLED, get_wikipedia_schema],
@@ -668,6 +708,13 @@ class LlmIntentsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle SearXNG configuration step."""
         return await self.handle_step(STEP_SEARXNG, user_input)
+
+    async def async_step_tavily(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Handle Tavily configuration step."""
+        return await self.handle_step(STEP_TAVILY, user_input)
 
     async def async_step_google_places(
         self,
@@ -909,6 +956,13 @@ class LlmIntentsOptionsFlow(config_entries.OptionsFlowWithReload):
     ) -> FlowResult:
         """Handle SearXNG configuration step in options flow."""
         return await self.handle_step(STEP_SEARXNG, user_input)
+
+    async def async_step_tavily(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Handle Tavily configuration step in options flow."""
+        return await self.handle_step(STEP_TAVILY, user_input)
 
     async def async_step_google_places(
         self,

--- a/custom_components/llm_intents/const.py
+++ b/custom_components/llm_intents/const.py
@@ -43,11 +43,13 @@ CONF_SEARCH_PROVIDER = "search_provider"
 CONF_SEARCH_PROVIDER_BRAVE = "Brave"
 CONF_SEARCH_PROVIDER_BRAVE_LLM = "Brave LLM Context"
 CONF_SEARCH_PROVIDER_SEARXNG = "SearXNG"
+CONF_SEARCH_PROVIDER_TAVILY = "Tavily"
 
 CONF_SEARCH_PROVIDERS = {
     "Brave": CONF_SEARCH_PROVIDER_BRAVE,
     "Brave LLM Context": CONF_SEARCH_PROVIDER_BRAVE_LLM,
     "SearXNG": CONF_SEARCH_PROVIDER_SEARXNG,
+    "Tavily": CONF_SEARCH_PROVIDER_TAVILY,
 }
 
 # SearXNG-specific constants
@@ -55,17 +57,23 @@ CONF_SEARCH_PROVIDERS = {
 CONF_SEARXNG_URL = "searxng_server_url"
 CONF_SEARXNG_NUM_RESULTS = "searxng_num_results"
 
+# Tavily-specific constants
+
+CONF_TAVILY_NUM_RESULTS = "tavily_num_results"
+
 # Provider API keys - shared across tools using the same backend
 
 CONF_PROVIDER_API_KEYS = "provider_api_keys"
 PROVIDER_GOOGLE = "google"
 PROVIDER_BRAVE = "brave"
 PROVIDER_BRAVE_LLM = "brave_llm"
+PROVIDER_TAVILY = "tavily"
 
 # Form field keys for provider API keys
 
 CONF_GOOGLE_API_KEY = "google_api_key"
 CONF_BRAVE_API_KEY = "brave_api_key"
+CONF_TAVILY_API_KEY = "tavily_api_key"
 
 # Brave-specific constants
 
@@ -172,6 +180,8 @@ SERVICE_DEFAULTS = {
     CONF_BRAVE_CONTEXT_THRESHOLD_MODE: "balanced",
     CONF_SEARXNG_URL: "",
     CONF_SEARXNG_NUM_RESULTS: 2,
+    CONF_TAVILY_API_KEY: "",
+    CONF_TAVILY_NUM_RESULTS: 2,
     CONF_GOOGLE_PLACES_NUM_RESULTS: 2,
     CONF_GOOGLE_PLACES_LATITUDE: "",
     CONF_GOOGLE_PLACES_LONGITUDE: "",

--- a/custom_components/llm_intents/llm_functions.py
+++ b/custom_components/llm_intents/llm_functions.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import llm
 
-from . import CONF_SEARCH_PROVIDER, CONF_SEARCH_PROVIDER_BRAVE
+from . import CONF_SEARCH_PROVIDER, CONF_SEARCH_PROVIDER_BRAVE, CONF_SEARCH_PROVIDER_TAVILY
 from .brave_llm_context_search import BraveLlmContextSearchTool
 from .brave_web_search import BraveSearchTool
 from .calculator import CalculatorTool
@@ -35,6 +35,7 @@ from .date_info import DateInfoTool
 from .google_places import FindPlacesTool
 from .play_media import PlayVideoTool
 from .searxng_search import SearXngSearchTool
+from .tavily_search import TavilySearchTool
 from .unit_converter import UnitConverterTool
 from .weather import WeatherForecastTool
 from .wikipedia import SearchWikipediaTool
@@ -54,6 +55,10 @@ SEARCH_CONF_ENABLED_MAP = [
     (
         lambda data: data.get(CONF_SEARCH_PROVIDER) == CONF_SEARCH_PROVIDER_SEARXNG,
         SearXngSearchTool,
+    ),
+    (
+        lambda data: data.get(CONF_SEARCH_PROVIDER) == CONF_SEARCH_PROVIDER_TAVILY,
+        TavilySearchTool,
     ),
     (CONF_GOOGLE_PLACES_ENABLED, FindPlacesTool),
     (CONF_YOUTUBE_ENABLED, SearchYouTubeTool),

--- a/custom_components/llm_intents/manifest.json
+++ b/custom_components/llm_intents/manifest.json
@@ -15,7 +15,8 @@
     "custom_components.llm_intents"
   ],
   "requirements": [
-    "sympy>=1.14.0"
+    "sympy>=1.14.0",
+    "tavily-python>=0.3"
   ],
   "version": "1.7.2"
 }

--- a/custom_components/llm_intents/tavily_search.py
+++ b/custom_components/llm_intents/tavily_search.py
@@ -1,0 +1,48 @@
+"""Tavily web search tool."""
+
+import asyncio
+import logging
+
+from tavily import TavilyClient
+
+from .base_web_search import SearchWebTool
+from .const import (
+    CONF_PROVIDER_API_KEYS,
+    CONF_TAVILY_NUM_RESULTS,
+    PROVIDER_TAVILY,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TavilySearchTool(SearchWebTool):
+    """Tavily web search tool."""
+
+    async def async_search(
+        self,
+        query: str,
+    ) -> list:
+        """Call the tool."""
+        provider_keys = self.config.get(CONF_PROVIDER_API_KEYS) or {}
+        api_key = provider_keys.get(PROVIDER_TAVILY, "")
+        num_results = int(self.config.get(CONF_TAVILY_NUM_RESULTS, 2))
+
+        if not api_key:
+            msg = "Tavily API key not configured"
+            raise RuntimeError(msg)
+
+        client = TavilyClient(api_key=api_key)
+        response = await asyncio.to_thread(
+            client.search,
+            query=query,
+            max_results=num_results,
+            search_depth="basic",
+        )
+
+        results = []
+        for result in response.get("results", []):
+            title = result.get("title", "")
+            content = await self.cleanup_text(result.get("content", ""))
+            item = {"title": title, "content": content}
+            results.append(item)
+        return results

--- a/custom_components/llm_intents/translations/en.json
+++ b/custom_components/llm_intents/translations/en.json
@@ -54,6 +54,14 @@
           "searxng_server_url": "Protocol, host, and port, eg: http://localhost:8080"
         }
       },
+      "tavily": {
+        "title": "Configure Tavily Web Search",
+        "description": "Configure Tavily Web Search API settings.",
+        "data": {
+          "tavily_api_key": "API Key",
+          "tavily_num_results": "Number of Results"
+        }
+      },
       "google_places": {
         "title": "Configure Google Places",
         "description": "Configure Google Places API settings.",
@@ -175,6 +183,14 @@
         },
         "data_description": {
           "searxng_server_url": "Protocol, host, and port, eg: http://localhost:8080"
+        }
+      },
+      "tavily": {
+        "title": "Configure Tavily Web Search",
+        "description": "Configure Tavily Web Search API settings.",
+        "data": {
+          "tavily_api_key": "API Key",
+          "tavily_num_results": "Number of Results"
         }
       },
       "google_places": {


### PR DESCRIPTION
## Summary

Adds Tavily as a new web search provider option alongside existing Brave, Brave LLM Context, and SearXNG providers. Users can select Tavily from the search provider dropdown and configure their API key and number of results.

This is an **additive** change — all existing providers remain untouched.

## Changes

### New file
- **`custom_components/llm_intents/tavily_search.py`** — `TavilySearchTool` extending `SearchWebTool`, using `asyncio.to_thread` to wrap the synchronous `tavily-python` SDK client

### Modified files
- **`custom_components/llm_intents/const.py`** — Added `CONF_SEARCH_PROVIDER_TAVILY`, `PROVIDER_TAVILY`, `CONF_TAVILY_API_KEY`, `CONF_TAVILY_NUM_RESULTS` constants; registered Tavily in `CONF_SEARCH_PROVIDERS` dict and `SERVICE_DEFAULTS`
- **`custom_components/llm_intents/config_flow.py`** — Added `STEP_TAVILY`, `get_tavily_schema()`, Tavily entry in `SEARCH_STEP_ORDER`, `async_step_tavily` in both `LlmIntentsConfigFlow` and `LlmIntentsOptionsFlow`; updated `expand_config_for_schema` and `merge_provider_api_keys_from_input` to handle Tavily API key
- **`custom_components/llm_intents/llm_functions.py`** — Imported `TavilySearchTool` and `CONF_SEARCH_PROVIDER_TAVILY`; added dispatch tuple to `SEARCH_CONF_ENABLED_MAP`
- **`custom_components/llm_intents/manifest.json`** — Added `tavily-python>=0.3` to requirements
- **`custom_components/llm_intents/translations/en.json`** — Added `tavily` step labels under both `config.step` and `options.step`

## Dependency changes
- Added `tavily-python>=0.3` to `manifest.json` requirements

## Environment variable changes
- None — Tavily API key is stored via the HA config-entry `CONF_PROVIDER_API_KEYS` dict (same pattern as Brave)

## Notes for reviewers
- The `tavily-python` SDK is synchronous, so `async_search()` wraps calls with `asyncio.to_thread`
- The Tavily API key follows the same `CONF_PROVIDER_API_KEYS` / `PROVIDER_TAVILY` storage pattern as Brave
- All existing providers and their configurations are unchanged


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily provider migration is well-implemented, complete, and consistent with existing patterns. All 6 files from the plan are modified correctly. The TavilySearchTool correctly extends SearchWebTool, uses asyncio.to_thread to bridge the synchronous SDK in HA's async environment (matching the Brave/SearXNG approach pattern), reads the API key from CONF_PROVIDER_API_KEYS (consistent with BraveSearchTool), and the config flow registration follows the exact same pattern as the existing SearXNG step. Only minor issues found, none blocking.
