### PR TITLE
feat: add Scene Presets API for LLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Additional tools for LLM-backed Assist for Home Assistant:
 * **Weather Forecast**
 * **YouTube Search and Playback**
 * **Basic Utilities** — Calculator, Kitchen Unit Converter, and Date Information
+* **Scene Presets** — Atmospheric lighting scenes via [hass-scene_presets](https://github.com/Hypfer/hass-scene_presets)
 
 Each tool is optional and configurable via the integrations UI. Some tools require API keys, but are usable on free tiers.
 A caching layer is utilised in order to reduce both API usage and latency on repeated requests for the same information within a 2-hour period.
@@ -65,6 +66,7 @@ the `Control Home Assistant` heading, and enabling the services desired for the 
 - Weather Forecast
 - Media Services
 - Basic Utilities
+- Scene Presets
 
 ### 🔍 Brave Web Search
 
@@ -365,6 +367,20 @@ Returns the day of the week and a formatted date string for a given day, month, 
 | `day`     | ✅        | Day of the month (1–31)                        |
 | `month`   | ✅        | Month (1–12)                                   |
 | `year`    | ❌        | Year (1900–2100, defaults to the current year) |
+
+---
+
+### 💡 Scene Presets
+
+Exposes [hass-scene_presets](https://github.com/Hypfer/hass-scene_presets) to your LLM, allowing it to apply atmospheric lighting scenes by mood or preset name. Custom user-defined presets are supported.
+
+#### Requirements
+
+* The [hass-scene_presets](https://github.com/Hypfer/hass-scene_presets) integration must be installed.
+
+#### Configuration Steps
+
+1. Enable "Scene Presets" during setup, or via Configure Scene Presets in the integration options.
 
 ---
 

--- a/custom_components/llm_intents/config_flow.py
+++ b/custom_components/llm_intents/config_flow.py
@@ -71,6 +71,7 @@ from .const import (
     CONF_HOME_CONTROL_PROMPT_TEMPLATE,
     CONF_HOURLY_WEATHER_ENTITY,
     CONF_PROVIDER_API_KEYS,
+    CONF_SCENE_PRESETS_ENABLED,
     CONF_SEARCH_PROVIDER,
     CONF_SEARCH_PROVIDER_BRAVE,
     CONF_SEARCH_PROVIDER_BRAVE_LLM,
@@ -111,6 +112,7 @@ STEP_HOME_CONTROL = "home_control"
 STEP_CONFIGURE_SEARCH = "configure"
 STEP_CONFIGURE_WEATHER = "configure_weather"
 STEP_CONFIGURE_BASIC_UTILITIES = "configure_basic_utilities"
+STEP_CONFIGURE_SCENE_PRESETS = "configure_scene_presets"
 
 
 class NullableNumberSelector(NumberSelector):
@@ -152,6 +154,7 @@ def get_step_user_data_schema(hass: HomeAssistant) -> vol.Schema:
         vol.Optional(CONF_WIKIPEDIA_ENABLED, default=False): bool,
         vol.Optional(CONF_WEATHER_ENABLED, default=False): bool,
         vol.Optional(CONF_BASIC_UTILITIES_ENABLED, default=False): bool,
+        vol.Optional(CONF_SCENE_PRESETS_ENABLED, default=False): bool,
         vol.Optional(CONF_HOME_CONTROL_ENABLED, default=False): bool,
     }
     return vol.Schema(schema)
@@ -847,6 +850,7 @@ class LlmIntentsOptionsFlow(config_entries.OptionsFlowWithReload):
                 step_id=STEP_INIT,
                 menu_options=[
                     STEP_CONFIGURE_BASIC_UTILITIES,
+                    STEP_CONFIGURE_SCENE_PRESETS,
                     STEP_HOME_CONTROL,
                     STEP_CONFIGURE_SEARCH,
                     STEP_CONFIGURE_WEATHER,
@@ -1091,6 +1095,30 @@ class LlmIntentsOptionsFlow(config_entries.OptionsFlowWithReload):
                 data_schema=schema,
             )
 
+        return self.async_create_entry(data=self.config_data)
+
+    async def async_step_configure_scene_presets(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Handle the configure Scene Presets menu option."""
+        defaults = {**self.config_entry.data, **(self.config_entry.options or {})}
+
+        if user_input is None:
+            schema = vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SCENE_PRESETS_ENABLED,
+                        default=defaults.get(CONF_SCENE_PRESETS_ENABLED, False),
+                    ): bool,
+                },
+            )
+            return self.async_show_form(
+                step_id=STEP_CONFIGURE_SCENE_PRESETS,
+                data_schema=schema,
+            )
+
+        self.config_data.update(user_input)
         return self.async_create_entry(data=self.config_data)
 
     async def async_step_basic_utilities(

--- a/custom_components/llm_intents/const.py
+++ b/custom_components/llm_intents/const.py
@@ -13,6 +13,7 @@ WEATHER_API_NAME = "Weather Forecast"
 MEDIA_API_NAME = "Media Services"
 BASIC_UTILITIES_API_NAME = "Basic Utilities"
 HOME_CONTROL_API_NAME = "Home Control"
+SCENE_PRESETS_API_NAME = "Scene Presets"
 
 # SQLite Cache
 
@@ -30,6 +31,12 @@ Use the Media Services tools to play video content on media player devices.
 
 BASIC_UTILITIES_SERVICES_PROMPT = """
 Use the Basic Utilities tools for calculations and unit conversions.
+"""
+
+SCENE_PRESETS_SERVICES_PROMPT = """
+Use SetLightingScene to apply a lighting scene or mood to a room or specific lights.
+For any scene, mood, preset, or ambiance request, call SetLightingScene with mood and area_ids.
+Do not use HassLightSet or HassTurnOn for mood or scene requests.
 """
 
 # Basic Utilities constants
@@ -170,6 +177,9 @@ CONF_WEATHER_DATA_PRECIPITATION = "weather_data_precipitation"
 CONF_WEATHER_DATA_WIND_SPEED = "weather_data_wind_speed"
 CONF_WEATHER_TEMPERATURE_SENSOR = "current_temperature_entity"
 
+# Scene Presets constants
+CONF_SCENE_PRESETS_ENABLED = "scene_presets_enabled"
+
 # Home Control constants
 CONF_HOME_CONTROL_ENABLED = "home_control_enabled"
 CONF_HOME_CONTROL_PROMPT_TEMPLATE = "home_control_prompt"
@@ -248,6 +258,7 @@ SERVICE_DEFAULTS = {
     CONF_CALCULATOR_ENABLED: True,
     CONF_UNIT_CONVERTER_ENABLED: True,
     CONF_DATE_INFO_ENABLED: True,
+    CONF_SCENE_PRESETS_ENABLED: False,
 }
 
 # To satisfy ruff

--- a/custom_components/llm_intents/llm_functions.py
+++ b/custom_components/llm_intents/llm_functions.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_GOOGLE_PLACES_ENABLED,
     CONF_GOOGLE_ROUTES_ENABLED,
     CONF_HOME_CONTROL_ENABLED,
+    CONF_SCENE_PRESETS_ENABLED,
     CONF_SEARCH_PROVIDER_BRAVE_LLM,
     CONF_SEARCH_PROVIDER_SEARXNG,
     CONF_UNIT_CONVERTER_ENABLED,
@@ -29,6 +30,8 @@ from .const import (
     DOMAIN,
     MEDIA_API_NAME,
     MEDIA_SERVICES_PROMPT,
+    SCENE_PRESETS_API_NAME,
+    SCENE_PRESETS_SERVICES_PROMPT,
     SEARCH_API_NAME,
     SEARCH_SERVICES_PROMPT,
     WEATHER_API_NAME,
@@ -39,6 +42,11 @@ from .google_places import FindPlacesTool
 from .google_routes import GetRouteTool
 from .home_control import HomeControlAPI
 from .play_media import PlayVideoTool
+from .scene_presets_tools import (
+    ApplyScenePresetTool,
+    ListScenePresetsTool,
+    StopDynamicScenesTool,
+)
 from .searxng_search import SearXngSearchTool
 from .unit_converter import UnitConverterTool
 from .weather import WeatherForecastTool
@@ -79,6 +87,12 @@ BASIC_UTILITIES_CONF_ENABLED_MAP = [
     (CONF_CALCULATOR_ENABLED, CalculatorTool),
     (CONF_UNIT_CONVERTER_ENABLED, UnitConverterTool),
     (CONF_DATE_INFO_ENABLED, DateInfoTool),
+]
+
+SCENE_PRESETS_CONF_ENABLED_MAP = [
+    (CONF_SCENE_PRESETS_ENABLED, ListScenePresetsTool),
+    (CONF_SCENE_PRESETS_ENABLED, ApplyScenePresetTool),
+    (CONF_SCENE_PRESETS_ENABLED, StopDynamicScenesTool),
 ]
 
 
@@ -169,6 +183,13 @@ class BasicUtilitiesAPI(BaseAPI):
     _API_PROMPT = BASIC_UTILITIES_SERVICES_PROMPT
 
 
+class ScenePresetsAPI(BaseAPI):
+    """Scene Presets API for LLM integration."""
+
+    _TOOLS_CONF_MAP = SCENE_PRESETS_CONF_ENABLED_MAP
+    _API_PROMPT = SCENE_PRESETS_SERVICES_PROMPT
+
+
 async def setup_llm_functions(hass: HomeAssistant, config_data: dict[str, Any]) -> None:
     """Set up LLM functions for search services."""
     # Check if already set up with same config to avoid unnecessary work
@@ -189,12 +210,14 @@ async def setup_llm_functions(hass: HomeAssistant, config_data: dict[str, Any]) 
     weather_api = WeatherAPI(hass, WEATHER_API_NAME)
     media_api = MediaAPI(hass, MEDIA_API_NAME)
     basic_utilities_api = BasicUtilitiesAPI(hass, BASIC_UTILITIES_API_NAME)
+    scene_presets_api = ScenePresetsAPI(hass, SCENE_PRESETS_API_NAME)
     home_control_api = HomeControlAPI(hass)
 
     hass.data[DOMAIN]["api"] = search_api
     hass.data[DOMAIN]["weather_api"] = weather_api
     hass.data[DOMAIN]["media_api"] = media_api
     hass.data[DOMAIN]["basic_utilities_api"] = basic_utilities_api
+    hass.data[DOMAIN]["scene_presets_api"] = scene_presets_api
     hass.data[DOMAIN]["customised_assist"] = home_control_api
     hass.data[DOMAIN]["config"] = config_data.copy()
     hass.data[DOMAIN]["unregister_api"] = []
@@ -219,6 +242,11 @@ async def setup_llm_functions(hass: HomeAssistant, config_data: dict[str, Any]) 
         if basic_utilities_api.get_enabled_tools():
             hass.data[DOMAIN]["unregister_api"].append(
                 llm.async_register_api(hass, basic_utilities_api),
+            )
+
+        if scene_presets_api.get_enabled_tools():
+            hass.data[DOMAIN]["unregister_api"].append(
+                llm.async_register_api(hass, scene_presets_api),
             )
 
         if config_data.get(CONF_HOME_CONTROL_ENABLED, False):

--- a/custom_components/llm_intents/scene_presets_tools.py
+++ b/custom_components/llm_intents/scene_presets_tools.py
@@ -1,0 +1,375 @@
+"""Scene Presets LLM tools."""
+
+import json
+import logging
+import random
+from pathlib import Path
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import llm
+from homeassistant.util.json import JsonObjectType
+
+from .base_tool import BaseTool
+
+_LOGGER = logging.getLogger(__name__)
+
+SCENE_PRESETS_DOMAIN = "scene_presets"
+
+
+def _load_presets(hass: HomeAssistant) -> dict:
+    """Load preset data from scene_presets installation."""
+    base = Path(hass.config.config_dir) / "custom_components" / "scene_presets"
+    presets_path = base / "presets.json"
+    if not presets_path.exists():
+        return {}
+    try:
+        with presets_path.open() as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        _LOGGER.warning("Could not load presets.json: %s", e)
+        return {}
+
+    custom_path = base / "userdata" / "custom" / "presets.json"
+    if custom_path.exists():
+        try:
+            with custom_path.open() as f:
+                custom = json.load(f)
+            data.setdefault("presets", []).extend(
+                [{**p, "custom": True} for p in custom.get("presets", [])]
+            )
+            data.setdefault("categories", []).extend(
+                [{**c, "custom": True} for c in custom.get("categories", [])]
+            )
+        except json.JSONDecodeError as e:
+            _LOGGER.warning("Could not load custom presets: %s", e)
+
+    return data
+
+
+def _find_preset_by_name(data: dict, name: str) -> dict | None:
+    """Find a preset by case-insensitive name match."""
+    name_lower = name.lower().strip()
+    for preset in data.get("presets", []):
+        if preset.get("name", "").lower() == name_lower:
+            return preset
+    return None
+
+
+def _build_targets(entity_ids: list[str], area_ids: list[str]) -> dict[str, list[str]]:
+    """Build a scene_presets targets dict from entity and area ID lists."""
+    targets: dict[str, list[str]] = {}
+    if entity_ids:
+        targets["entity_id"] = entity_ids
+    if area_ids:
+        targets["area_id"] = area_ids
+    return targets
+
+
+def _find_preset_by_mood(data: dict, mood: str) -> dict | None:
+    """Return a random preset whose category name matches mood (case-insensitive)."""
+    mood_lower = mood.lower().strip()
+    categories = {c["id"]: c["name"] for c in data.get("categories", [])}
+    matches = [
+        p
+        for p in data.get("presets", [])
+        if categories.get(p.get("categoryId", ""), "").lower() == mood_lower
+    ]
+    return random.choice(matches) if matches else None  # noqa: S311
+
+
+def _resolve_area_ids(hass: HomeAssistant, area_ids: list[str]) -> list[str]:
+    """Resolve area display names or aliases to HA area ID slugs."""
+    if not area_ids:
+        return area_ids
+    try:
+        registry = ar.async_get(hass)
+        resolved = []
+        for area_id in area_ids:
+            if registry.async_get_area(area_id):
+                resolved.append(area_id)
+                continue
+            area = registry.async_get_area_by_name(area_id)
+            if area is None:
+                matches = registry.async_get_areas_by_alias(area_id)
+                area = matches[0] if matches else None
+            resolved.append(area.id if area else area_id)
+        return resolved
+    except AttributeError:
+        return area_ids
+
+
+def _lookup_preset(
+    data: dict, mood: str | None, preset_name: str | None
+) -> tuple[dict | None, dict | None]:
+    """Resolve mood or preset_name to a preset entry, or return an error dict."""
+    if mood:
+        preset = _find_preset_by_mood(data, mood)
+        if not preset:
+            categories = sorted({c["name"] for c in data.get("categories", [])})
+            return None, {
+                "error": f"No mood '{mood}' found.",
+                "available_moods": categories,
+            }
+        return preset, None
+    preset = _find_preset_by_name(data, preset_name) or _find_preset_by_mood(
+        data, preset_name
+    )
+    if not preset:
+        return None, {
+            "error": f"No preset or mood named '{preset_name}' found. Call ListScenePresets to see available options.",
+            "available_count": len(data.get("presets", [])),
+        }
+    return preset, None
+
+
+def _scene_presets_available(hass: HomeAssistant) -> bool:
+    return hass.services.has_service(SCENE_PRESETS_DOMAIN, "apply_preset")
+
+
+class ListScenePresetsTool(BaseTool):
+    """Tool to list available scene presets."""
+
+    name = "ListScenePresets"
+    description = (
+        "List all available scene presets with their names, IDs, and categories. "
+        "Call this first to discover preset names before applying one."
+    )
+    prompt_description = None
+    parameters = vol.Schema({})
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Call the tool."""
+        if not _scene_presets_available(hass):
+            return {"error": "scene_presets integration is not installed or loaded"}
+
+        data = _load_presets(hass)
+        if not data:
+            return {"error": "Could not load scene presets data"}
+
+        categories = {c["id"]: c["name"] for c in data.get("categories", [])}
+        moods = sorted(categories.values())
+        presets = [
+            {
+                "name": p["name"],
+                "id": p["id"],
+                "mood": categories.get(p.get("categoryId", ""), "Defaults"),
+                **({"custom": True} if p.get("custom") else {}),
+            }
+            for p in data.get("presets", [])
+        ]
+        return {"moods": moods, "presets": presets}
+
+
+class ApplyScenePresetTool(BaseTool):
+    """Tool to apply a scene preset to lights."""
+
+    name = "SetLightingScene"
+    description = "Set a lighting scene or mood in a room. Provide mood and area_ids."
+    prompt_description = (
+        "Use SetLightingScene whenever the user requests a lighting scene, mood, or ambiance. "
+        "Provide mood or preset_name along with area_ids or entity_ids. "
+        "For requests that only change brightness, use HassLightSet instead. "
+        "After applying a scene, tell the user which mood and preset were used "
+        "(from the 'mood' and 'preset' fields in the response). "
+        "When making an existing scene dynamic, pass the preset name from the previous response "
+        "as preset_name rather than using mood, so the same preset is kept."
+    )
+
+    @staticmethod
+    def update_args(hass: HomeAssistant) -> None:
+        """Stamp available moods from presets.json into the tool description."""
+        presets_path = (
+            Path(hass.config.config_dir)
+            / "custom_components"
+            / "scene_presets"
+            / "presets.json"
+        )
+        if not presets_path.exists():
+            return
+        try:
+            with presets_path.open() as f:
+                data = json.load(f)
+            moods = ", ".join(c["name"] for c in data.get("categories", []))
+        except (OSError, json.JSONDecodeError):
+            return
+        ApplyScenePresetTool.description = (
+            "Set a lighting scene or mood in a room. Use this tool directly without asking for confirmation. "
+            f"Available moods: {moods}. "
+            "Use for requests like 'set the bedroom light to party', 'set bedroom lights to cozy', "
+            "'make it relaxing', 'scene preset', or any mood or ambiance request. "
+            "Provide mood and area_ids (e.g. area_ids=['bedroom'])."
+        )
+
+    parameters = vol.Schema(
+        {
+            vol.Optional(
+                "mood",
+                description="Mood or ambiance category (e.g. 'Cozy', 'Refreshing', 'Party vibes', 'Serenity'). Use this instead of preset_name when the user describes an atmosphere.",
+            ): str,
+            vol.Optional(
+                "preset_name",
+                description="Exact preset name (e.g. 'Relax', 'Arctic aurora'). Use mood instead when the user describes a general atmosphere.",
+            ): str,
+            vol.Optional(
+                "entity_ids",
+                description="Light entity IDs to apply the preset to (e.g. ['light.bedroom_lamp'])",
+            ): [str],
+            vol.Optional(
+                "area_ids",
+                description="Area IDs to apply the preset to (e.g. ['living_room', 'bedroom'])",
+            ): [str],
+            vol.Optional(
+                "brightness",
+                description="Override brightness (0-255). Omit to use preset default.",
+            ): vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+            vol.Optional(
+                "dynamic",
+                description="Start an endlessly looping dynamic scene instead of a one-shot apply. Default false.",
+            ): bool,
+            vol.Optional(
+                "interval",
+                description="Seconds between color changes for a dynamic scene (5-300). Default 60.",
+            ): vol.All(vol.Coerce(int), vol.Range(min=5, max=300)),
+        }
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Call the tool."""
+        if not _scene_presets_available(hass):
+            return {"error": "scene_presets integration is not installed or loaded"}
+
+        args = tool_input.tool_args
+        mood = args.get("mood")
+        preset_name = args.get("preset_name")
+
+        if not mood and not preset_name:
+            return {"error": "Provide either mood or preset_name"}
+
+        data = _load_presets(hass)
+        preset, err = _lookup_preset(data, mood, preset_name)
+        if err:
+            return err
+
+        entity_ids = args.get("entity_ids") or []
+        area_ids = args.get("area_ids") or []
+        if not entity_ids and not area_ids:
+            return {"error": "Must specify at least one entity_id or area_id"}
+
+        area_ids = _resolve_area_ids(hass, area_ids)
+        targets = _build_targets(entity_ids, area_ids)
+
+        is_dynamic = args.get("dynamic", False)
+        service_data: dict = {
+            "preset_id": preset["id"],
+            "targets": targets,
+            "transition": 1,
+        }
+        if (brightness := args.get("brightness")) is not None:
+            service_data["brightness"] = brightness
+
+        if is_dynamic:
+            service_data["interval"] = args.get("interval", 60)
+            service_name = "start_dynamic_scene"
+        else:
+            service_name = "apply_preset"
+
+        try:
+            await hass.services.async_call(
+                SCENE_PRESETS_DOMAIN,
+                service_name,
+                service_data,
+                blocking=True,
+            )
+        except Exception as e:
+            _LOGGER.exception("Error applying scene preset '%s'", preset["name"])
+            return {"error": str(e)}
+
+        result = {
+            "success": True,
+            "preset": preset["name"],
+            "dynamic": is_dynamic,
+            "targets": targets,
+        }
+        if mood:
+            result["mood"] = mood
+        return result
+
+
+class StopDynamicScenesTool(BaseTool):
+    """Tool to stop dynamic scenes on lights."""
+
+    name = "StopDynamicScenes"
+    description = (
+        "Stop all active dynamic (looping) scenes on the specified lights or areas. "
+        "Provide entity_ids and/or area_ids to stop scenes only on those targets, "
+        "or call with no arguments to stop all dynamic scenes everywhere."
+    )
+    prompt_description = None
+
+    parameters = vol.Schema(
+        {
+            vol.Optional(
+                "entity_ids",
+                description="Light entity IDs to stop dynamic scenes on",
+            ): [str],
+            vol.Optional(
+                "area_ids",
+                description="Area IDs to stop dynamic scenes on",
+            ): [str],
+            vol.Optional(
+                "stop_all",
+                description="Set to true to stop all dynamic scenes regardless of target",
+            ): bool,
+        }
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Call the tool."""
+        if not _scene_presets_available(hass):
+            return {"error": "scene_presets integration is not installed or loaded"}
+
+        args = tool_input.tool_args
+        stop_all = args.get("stop_all", False)
+        entity_ids = args.get("entity_ids") or []
+        area_ids = args.get("area_ids") or []
+
+        if stop_all or (not entity_ids and not area_ids):
+            await hass.services.async_call(
+                SCENE_PRESETS_DOMAIN,
+                "stop_all_dynamic_scenes",
+                {},
+                blocking=True,
+            )
+            return {"success": True, "stopped": "all"}
+
+        targets = _build_targets(entity_ids, area_ids)
+
+        try:
+            await hass.services.async_call(
+                SCENE_PRESETS_DOMAIN,
+                "stop_dynamic_scenes_for_targets",
+                {"targets": targets},
+                blocking=True,
+            )
+        except Exception as e:
+            _LOGGER.exception("Error stopping dynamic scenes")
+            return {"error": str(e)}
+
+        return {"success": True, "stopped_for": targets}

--- a/custom_components/llm_intents/translations/en.json
+++ b/custom_components/llm_intents/translations/en.json
@@ -11,7 +11,8 @@
           "youtube_enabled": "Enable YouTube Search",
           "wikipedia_enabled": "Enable Wikipedia Search",
           "weather_enabled": "Enable Weather Forecast",
-          "basic_utilities_enabled": "Enable Basic Utilities"
+          "basic_utilities_enabled": "Enable Basic Utilities",
+          "scene_presets_enabled": "Enable Scene Presets"
         }
       },
       "brave": {
@@ -144,7 +145,8 @@
           "configure": "Configure Search Services",
           "configure_weather": "Configure Weather Forecast",
           "configure_basic_utilities": "Configure Basic Utilities",
-          "home_control": "Configure Home Control API"
+          "home_control": "Configure Home Control API",
+          "configure_scene_presets": "Configure Scene Presets"
         }
       },
       "configure": {
@@ -286,6 +288,13 @@
         "data_description": {
           "home_control_prompt": "Override the hidden tooling prompt that is injected by the Assist API. This can be useful if this contains conflicts with your Conversation Agents prompt",
           "home_control_disabled_tools": "Disable any of the standard Assist platform tools that you do not wish your model to have access to."
+        }
+      },
+      "configure_scene_presets": {
+        "title": "Configure Scene Presets",
+        "description": "Enable the Scene Presets lighting tool.",
+        "data": {
+          "scene_presets_enabled": "Enable Scene Presets"
         }
       }
     }

--- a/tests/test_scene_presets_tools.py
+++ b/tests/test_scene_presets_tools.py
@@ -1,0 +1,768 @@
+"""Tests for the scene_presets LLM tools."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
+
+from custom_components.llm_intents.scene_presets_tools import (
+    ApplyScenePresetTool,
+    ListScenePresetsTool,
+    StopDynamicScenesTool,
+    _find_preset_by_name,
+    _load_presets,
+    _resolve_area_ids,
+)
+
+SAMPLE_PRESETS_JSON = """{
+    "categories": [
+        {"id": "cat-defaults", "name": "Defaults"},
+        {"id": "cat-cozy", "name": "Cozy"}
+    ],
+    "presets": [
+        {"id": "uuid-relax", "name": "Relax", "categoryId": "cat-defaults", "bri": 200, "lights": []},
+        {"id": "uuid-energize", "name": "Energize", "categoryId": "cat-defaults", "bri": 255, "lights": []},
+        {"id": "uuid-cozy", "name": "Cozy Glow", "categoryId": "cat-cozy", "bri": 150, "lights": []}
+    ]
+}"""
+
+SAMPLE_CUSTOM_PRESETS_JSON = """{
+    "categories": [],
+    "presets": [
+        {"id": "uuid-custom", "name": "My Custom Scene", "categoryId": "", "bri": 180, "lights": []}
+    ]
+}"""
+
+SAMPLE_PRESET_DATA = {
+    "categories": [
+        {"id": "cat-defaults", "name": "Defaults"},
+        {"id": "cat-cozy", "name": "Cozy"},
+    ],
+    "presets": [
+        {"id": "uuid-relax", "name": "Relax", "categoryId": "cat-defaults"},
+        {"id": "uuid-energize", "name": "Energize", "categoryId": "cat-defaults"},
+        {"id": "uuid-cozy", "name": "Cozy Glow", "categoryId": "cat-cozy"},
+    ],
+}
+
+
+@pytest.fixture
+def mock_hass_with_scene_presets(mock_hass: HomeAssistant) -> HomeAssistant:
+    """Mock hass with scene_presets services available."""
+    mock_hass.services = MagicMock()
+    mock_hass.services.has_service.return_value = True
+    mock_hass.services.async_call = AsyncMock()
+    mock_hass.config = MagicMock()
+    mock_hass.config.config_dir = "/config"
+    return mock_hass
+
+
+@pytest.fixture
+def mock_hass_no_scene_presets(mock_hass: HomeAssistant) -> HomeAssistant:
+    """Mock hass without scene_presets services available."""
+    mock_hass.services = MagicMock()
+    mock_hass.services.has_service.return_value = False
+    mock_hass.config = MagicMock()
+    mock_hass.config.config_dir = "/config"
+    return mock_hass
+
+
+@pytest.fixture
+def llm_context() -> llm.LLMContext:
+    """Return a dummy LLM context."""
+    return llm.LLMContext(
+        platform="test", context=None, language="en", assistant=None, device_id=None
+    )
+
+
+# =============================================================================
+# _find_preset_by_name() tests
+# =============================================================================
+
+
+def test_find_preset_by_name_exact_match() -> None:
+    """Exact name match returns the correct preset."""
+    assert _find_preset_by_name(SAMPLE_PRESET_DATA, "Relax")["id"] == "uuid-relax"
+
+
+def test_find_preset_by_name_case_insensitive() -> None:
+    """Name lookup is case-insensitive."""
+    assert _find_preset_by_name(SAMPLE_PRESET_DATA, "relax")["id"] == "uuid-relax"
+    assert _find_preset_by_name(SAMPLE_PRESET_DATA, "RELAX")["id"] == "uuid-relax"
+    assert _find_preset_by_name(SAMPLE_PRESET_DATA, "cozy glow")["id"] == "uuid-cozy"
+
+
+def test_find_preset_by_name_not_found() -> None:
+    """Returns None when no preset matches the name."""
+    assert _find_preset_by_name(SAMPLE_PRESET_DATA, "Nonexistent") is None
+
+
+def test_find_preset_by_name_empty_data() -> None:
+    """Returns None when preset data is empty."""
+    assert _find_preset_by_name({}, "Relax") is None
+
+
+# =============================================================================
+# _load_presets() tests
+# =============================================================================
+
+
+def test_load_presets_missing_file() -> None:
+    """Returns empty dict when presets.json does not exist."""
+    hass = MagicMock()
+    hass.config.config_dir = "/config"
+    with patch("pathlib.Path.exists", return_value=False):
+        result = _load_presets(hass)
+    assert result == {}
+
+
+def test_load_presets_base_only() -> None:
+    """Loads presets.json when no custom file exists."""
+    hass = MagicMock()
+    hass.config.config_dir = "/config"
+
+    _call = [0]
+
+    def exists_side_effect() -> bool:
+        _call[0] += 1
+        return _call[0] == 1  # True for presets_path, False for custom_path
+
+    with (
+        patch("pathlib.Path.exists", side_effect=exists_side_effect),
+        patch("pathlib.Path.open", mock_open(read_data=SAMPLE_PRESETS_JSON)),
+    ):
+        result = _load_presets(hass)
+
+    assert len(result["presets"]) == 3
+    assert result["presets"][0]["name"] == "Relax"
+
+
+def test_load_presets_merges_custom() -> None:
+    """Custom presets are appended and flagged."""
+    hass = MagicMock()
+    hass.config.config_dir = "/config"
+
+    call_count = [0]
+
+    def open_side_effect(*args: Any, **kwargs: Any) -> Any:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return mock_open(read_data=SAMPLE_PRESETS_JSON)()
+        return mock_open(read_data=SAMPLE_CUSTOM_PRESETS_JSON)()
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.open", side_effect=open_side_effect),
+    ):
+        result = _load_presets(hass)
+
+    names = [p["name"] for p in result["presets"]]
+    assert "Relax" in names
+    assert "My Custom Scene" in names
+    custom = next(p for p in result["presets"] if p["name"] == "My Custom Scene")
+    assert custom.get("custom") is True
+
+
+# =============================================================================
+# _resolve_area_ids() tests
+# =============================================================================
+
+
+def _make_area_registry(
+    areas_by_id: dict, areas_by_name: dict, areas_by_alias: dict | None = None
+) -> MagicMock:
+    """Build a minimal area registry mock."""
+    reg = MagicMock()
+    reg.async_get_area.side_effect = areas_by_id.get
+    reg.async_get_area_by_name.side_effect = areas_by_name.get
+    reg.async_get_areas_by_alias.side_effect = lambda alias: (areas_by_alias or {}).get(
+        alias, []
+    )
+    return reg
+
+
+def test_resolve_area_ids_slug_passthrough() -> None:
+    """Already-valid slugs are returned unchanged."""
+    hass = MagicMock()
+    area = MagicMock()
+    area.id = "bedroom"
+    reg = _make_area_registry({"bedroom": area}, {})
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools.ar.async_get",
+        return_value=reg,
+    ):
+        result = _resolve_area_ids(hass, ["bedroom"])
+    assert result == ["bedroom"]
+
+
+def test_resolve_area_ids_name_to_slug() -> None:
+    """Display name 'Bedroom' is resolved to slug 'bedroom'."""
+    hass = MagicMock()
+    area = MagicMock()
+    area.id = "bedroom"
+    reg = _make_area_registry({}, {"Bedroom": area})
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools.ar.async_get",
+        return_value=reg,
+    ):
+        result = _resolve_area_ids(hass, ["Bedroom"])
+    assert result == ["bedroom"]
+
+
+def test_resolve_area_ids_unknown_passthrough() -> None:
+    """Unknown area IDs are passed through unchanged."""
+    hass = MagicMock()
+    reg = _make_area_registry({}, {})
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools.ar.async_get",
+        return_value=reg,
+    ):
+        result = _resolve_area_ids(hass, ["nonexistent"])
+    assert result == ["nonexistent"]
+
+
+def test_resolve_area_ids_by_alias() -> None:
+    """Area aliases are resolved to the area slug."""
+    hass = MagicMock()
+    area = MagicMock()
+    area.id = "living_room"
+    reg = _make_area_registry({}, {})
+    reg.async_get_areas_by_alias = MagicMock(return_value=[area])
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools.ar.async_get",
+        return_value=reg,
+    ):
+        result = _resolve_area_ids(hass, ["Lounge"])
+    assert result == ["living_room"]
+
+
+def test_resolve_area_ids_empty() -> None:
+    """Empty input returns immediately without touching the registry."""
+    hass = MagicMock()
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools.ar.async_get"
+    ) as mock_ar:
+        result = _resolve_area_ids(hass, [])
+    mock_ar.assert_not_called()
+    assert result == []
+
+
+# =============================================================================
+# ListScenePresetsTool tests
+# =============================================================================
+
+
+@pytest.fixture
+def list_tool(mock_hass_with_scene_presets: HomeAssistant) -> ListScenePresetsTool:
+    """Return a ListScenePresetsTool bound to a mock hass."""
+    return ListScenePresetsTool({}, mock_hass_with_scene_presets)
+
+
+@pytest.mark.asyncio
+async def test_list_presets_unavailable(
+    mock_hass_no_scene_presets: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Returns an error when scene_presets is not installed."""
+    tool = ListScenePresetsTool({}, mock_hass_no_scene_presets)
+    result = await tool.async_call(
+        mock_hass_no_scene_presets,
+        llm.ToolInput(tool_name="ListScenePresets", tool_args={}),
+        llm_context,
+    )
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_list_presets_missing_json(
+    mock_hass_with_scene_presets: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Returns an error when presets.json cannot be found."""
+    tool = ListScenePresetsTool({}, mock_hass_with_scene_presets)
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value={},
+    ):
+        result = await tool.async_call(
+            mock_hass_with_scene_presets,
+            llm.ToolInput(tool_name="ListScenePresets", tool_args={}),
+            llm_context,
+        )
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_list_presets_returns_all(
+    mock_hass_with_scene_presets: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Returns all presets with name, id, and category."""
+    tool = ListScenePresetsTool({}, mock_hass_with_scene_presets)
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await tool.async_call(
+            mock_hass_with_scene_presets,
+            llm.ToolInput(tool_name="ListScenePresets", tool_args={}),
+            llm_context,
+        )
+
+    assert "moods" in result
+    assert result["moods"] == ["Cozy", "Defaults"]
+    assert "presets" in result
+    presets = result["presets"]
+    assert len(presets) == 3
+    relax = next(p for p in presets if p["name"] == "Relax")
+    assert relax["id"] == "uuid-relax"
+    assert relax["mood"] == "Defaults"
+    cozy = next(p for p in presets if p["name"] == "Cozy Glow")
+    assert cozy["mood"] == "Cozy"
+
+
+# =============================================================================
+# ApplyScenePresetTool tests
+# =============================================================================
+
+
+@pytest.fixture
+def apply_tool(mock_hass_with_scene_presets: HomeAssistant) -> ApplyScenePresetTool:
+    """Return an ApplyScenePresetTool bound to a mock hass."""
+    return ApplyScenePresetTool({}, mock_hass_with_scene_presets)
+
+
+def _apply_input(**kwargs: Any) -> llm.ToolInput:
+    return llm.ToolInput(tool_name="SetLightingScene", tool_args=kwargs)
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_unavailable(
+    mock_hass_no_scene_presets: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Returns an error when scene_presets is not installed."""
+    tool = ApplyScenePresetTool({}, mock_hass_no_scene_presets)
+    result = await tool.async_call(
+        mock_hass_no_scene_presets,
+        _apply_input(preset_name="Relax", entity_ids=["light.x"]),
+        llm_context,
+    )
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_not_found(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Returns an error when the requested preset does not exist."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(preset_name="Does Not Exist", entity_ids=["light.x"]),
+            llm_context,
+        )
+    assert "error" in result
+    assert "Does Not Exist" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_no_targets(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Returns an error when neither entity_ids nor area_ids are provided."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(preset_name="Relax"),
+            llm_context,
+        )
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_entity_ids(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Calls apply_preset service with entity targets."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(preset_name="Relax", entity_ids=["light.bedroom"]),
+            llm_context,
+        )
+
+    assert result["success"] is True
+    assert result["preset"] == "Relax"
+    assert result["dynamic"] is False
+    mock_hass_with_scene_presets.services.async_call.assert_called_once_with(
+        "scene_presets",
+        "apply_preset",
+        {
+            "preset_id": "uuid-relax",
+            "targets": {"entity_id": ["light.bedroom"]},
+            "transition": 1,
+        },
+        blocking=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_area_ids(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Calls apply_preset service with area targets."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(preset_name="Energize", area_ids=["living_room"]),
+            llm_context,
+        )
+
+    assert result["success"] is True
+    call_args = mock_hass_with_scene_presets.services.async_call.call_args
+    assert call_args[0][2]["targets"] == {"area_id": ["living_room"]}
+    assert call_args[0][2]["preset_id"] == "uuid-energize"
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_mixed_targets(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Calls apply_preset with both entity_ids and area_ids."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(
+                preset_name="Relax",
+                entity_ids=["light.lamp"],
+                area_ids=["bedroom"],
+            ),
+            llm_context,
+        )
+
+    targets = mock_hass_with_scene_presets.services.async_call.call_args[0][2][
+        "targets"
+    ]
+    assert targets == {"entity_id": ["light.lamp"], "area_id": ["bedroom"]}
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_optional_params(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Brightness is forwarded correctly."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(
+                preset_name="Relax",
+                entity_ids=["light.x"],
+                brightness=128,
+            ),
+            llm_context,
+        )
+
+    data = mock_hass_with_scene_presets.services.async_call.call_args[0][2]
+    assert data["brightness"] == 128
+    assert data["transition"] == 1
+    assert "shuffle" not in data
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_dynamic(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """dynamic=True calls start_dynamic_scene with interval."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(
+                preset_name="Cozy Glow",
+                entity_ids=["light.living_room"],
+                dynamic=True,
+                interval=30,
+            ),
+            llm_context,
+        )
+
+    assert result["dynamic"] is True
+    call_args = mock_hass_with_scene_presets.services.async_call.call_args[0]
+    assert call_args[1] == "start_dynamic_scene"
+    assert call_args[2]["interval"] == 30
+    assert "shuffle" not in call_args[2]
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_dynamic_default_interval(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """dynamic=True defaults to 60s interval when not specified."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(preset_name="Relax", entity_ids=["light.x"], dynamic=True),
+            llm_context,
+        )
+
+    data = mock_hass_with_scene_presets.services.async_call.call_args[0][2]
+    assert data["interval"] == 60
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_service_error(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Service call failures are caught and returned as an error dict."""
+    mock_hass_with_scene_presets.services.async_call = AsyncMock(
+        side_effect=Exception("zigbee timeout")
+    )
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(preset_name="Relax", entity_ids=["light.x"]),
+            llm_context,
+        )
+
+    assert "error" in result
+    assert "zigbee timeout" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_no_name_or_mood(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Neither preset_name nor mood → error."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(area_ids=["bedroom"]),
+            llm_context,
+        )
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_by_mood(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Mood parameter resolves to a random preset in the matching category."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(mood="Cozy", area_ids=["bedroom"]),
+            llm_context,
+        )
+
+    assert result["success"] is True
+    assert result["preset"] == "Cozy Glow"
+    call_args = mock_hass_with_scene_presets.services.async_call.call_args[0]
+    assert call_args[2]["preset_id"] == "uuid-cozy"
+    assert call_args[2]["targets"] == {"area_id": ["bedroom"]}
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_by_mood_case_insensitive(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Mood lookup is case-insensitive."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(mood="cozy", area_ids=["bedroom"]),
+            llm_context,
+        )
+    assert result["success"] is True
+    assert result["preset"] == "Cozy Glow"
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_mood_not_found(
+    apply_tool: ApplyScenePresetTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Unknown mood returns error with available moods list."""
+    with patch(
+        "custom_components.llm_intents.scene_presets_tools._load_presets",
+        return_value=SAMPLE_PRESET_DATA,
+    ):
+        result = await apply_tool.async_call(
+            mock_hass_with_scene_presets,
+            _apply_input(mood="Psychedelic", area_ids=["bedroom"]),
+            llm_context,
+        )
+    assert "error" in result
+    assert "available_moods" in result
+    assert "Cozy" in result["available_moods"]
+
+
+# =============================================================================
+# StopDynamicScenesTool tests
+# =============================================================================
+
+
+@pytest.fixture
+def stop_tool(mock_hass_with_scene_presets: HomeAssistant) -> StopDynamicScenesTool:
+    """Return a StopDynamicScenesTool bound to a mock hass."""
+    return StopDynamicScenesTool({}, mock_hass_with_scene_presets)
+
+
+def _stop_input(**kwargs: Any) -> llm.ToolInput:
+    return llm.ToolInput(tool_name="StopDynamicScenes", tool_args=kwargs)
+
+
+@pytest.mark.asyncio
+async def test_stop_unavailable(
+    mock_hass_no_scene_presets: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Returns an error when scene_presets is not installed."""
+    tool = StopDynamicScenesTool({}, mock_hass_no_scene_presets)
+    result = await tool.async_call(
+        mock_hass_no_scene_presets, _stop_input(), llm_context
+    )
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_stop_all_when_no_args(
+    stop_tool: StopDynamicScenesTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """No arguments → stop_all_dynamic_scenes."""
+    result = await stop_tool.async_call(
+        mock_hass_with_scene_presets, _stop_input(), llm_context
+    )
+    assert result["stopped"] == "all"
+    mock_hass_with_scene_presets.services.async_call.assert_called_once_with(
+        "scene_presets", "stop_all_dynamic_scenes", {}, blocking=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_all_explicit(
+    stop_tool: StopDynamicScenesTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """stop_all=True → stop_all_dynamic_scenes regardless of targets."""
+    result = await stop_tool.async_call(
+        mock_hass_with_scene_presets,
+        _stop_input(stop_all=True, entity_ids=["light.x"]),
+        llm_context,
+    )
+    assert result["stopped"] == "all"
+    call_args = mock_hass_with_scene_presets.services.async_call.call_args[0]
+    assert call_args[1] == "stop_all_dynamic_scenes"
+
+
+@pytest.mark.asyncio
+async def test_stop_for_entity_ids(
+    stop_tool: StopDynamicScenesTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Stops dynamic scenes for specific entity IDs."""
+    result = await stop_tool.async_call(
+        mock_hass_with_scene_presets,
+        _stop_input(entity_ids=["light.bedroom", "light.lamp"]),
+        llm_context,
+    )
+    assert result["success"] is True
+    call_args = mock_hass_with_scene_presets.services.async_call.call_args[0]
+    assert call_args[1] == "stop_dynamic_scenes_for_targets"
+    assert call_args[2]["targets"] == {"entity_id": ["light.bedroom", "light.lamp"]}
+
+
+@pytest.mark.asyncio
+async def test_stop_for_area_ids(
+    stop_tool: StopDynamicScenesTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Stops dynamic scenes for specific area IDs."""
+    await stop_tool.async_call(
+        mock_hass_with_scene_presets,
+        _stop_input(area_ids=["living_room"]),
+        llm_context,
+    )
+    call_args = mock_hass_with_scene_presets.services.async_call.call_args[0]
+    assert call_args[1] == "stop_dynamic_scenes_for_targets"
+    assert call_args[2]["targets"] == {"area_id": ["living_room"]}
+
+
+@pytest.mark.asyncio
+async def test_stop_service_error(
+    stop_tool: StopDynamicScenesTool,
+    mock_hass_with_scene_presets: HomeAssistant,
+    llm_context: llm.LLMContext,
+) -> None:
+    """Service call failures are caught and returned as an error dict."""
+    mock_hass_with_scene_presets.services.async_call = AsyncMock(
+        side_effect=Exception("service failed")
+    )
+    result = await stop_tool.async_call(
+        mock_hass_with_scene_presets,
+        _stop_input(entity_ids=["light.x"]),
+        llm_context,
+    )
+    assert "error" in result


### PR DESCRIPTION
This adds three new LLM tools to expose `hass-scene_presets` services: https://github.com/Hypfer/hass-scene_presets - listing scene presets, setting one, and removing a dynamic scene.

Tested with `gemma4:e4b`.