### PR TITLE
Fixed errors when attributes are None

### DIFF
--- a/custom_components/llm_intents/weather.py
+++ b/custom_components/llm_intents/weather.py
@@ -61,6 +61,8 @@ class ForecastRetrievalError(WeatherToolError):
 
 def _friendly_precipitation_chance(precipitation_chance: int) -> str:
     """Format the precipitation chance into string categories for the LLM."""
+    if precipitation_chance is None:
+        return "unknown"
     for threshold, value in PRECIPITATION_THRESHOLDS.items():
         if precipitation_chance <= threshold:
             return value
@@ -92,6 +94,8 @@ def _build_attributes(
     for attribute in attribute_list:
         if attribute.key in weather_data:
             attr_data = weather_data.get(attribute.key)
+            if attr_data is None:
+                continue
             output.append(
                 f"  {attribute.name}: {attribute.formatter(attr_data) if attribute.formatter else attr_data}",
             )


### PR DESCRIPTION
Hey,
I have had the following error when using the custom integration from [DWD](https://github.com/FL550/dwd_weather) as weather entity for the tool service:

```
tool_name: weather-forecast__GetWeatherForecast
tool_result:
  error: >-
    Error retrieving weather forecast: '<=' not supported between instances of
    'NoneType' and 'int'
```

The custom integration seems to have some values which are `None` but in this service being compared to `Int`.
Not quite sure if this is the best way to fix it, but it solved the issue for me.