### PR TITLE
feat: add SerpBase (Google) search engine via REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Additional tools for LLM-backed Assist for Home Assistant:
 
-* **Web Search** powered by your choice of _Brave_ or _SearXNG_
+* **Web Search** powered by your choice of _Brave_, _SearXNG_ or _SerpBase_
 * **Location Search** powered by Google Places
 * **Routes & Travel Time** powered by Google Routes
 * **Wikipedia**
@@ -148,6 +148,29 @@ Uses a self-hosted SearXNG search service to return summarized results.
 | Setting             | Required | Default | Description                             |
 |---------------------|----------|---------|-----------------------------------------|
 | `Number of Results` | ✅        | `2`     | Number of results to provide to the LLM |
+
+---
+
+### 🔍 SerpBase Web Search
+
+Uses the SerpBase Google Search Results API to return Google-ranked, snippet-rich results without running a browser or maintaining scrapers.
+
+##### Requirements
+
+* Requires a [SerpBase API key](https://serpbase.dev). 100 free searches per month, no credit card required.
+
+#### Configuration Steps
+
+1. Select "SerpBase" as the search provider during setup.
+2. Enter your [SerpBase API key](https://serpbase.dev/dashboard/api-keys).
+3. Configure the number of results to provide to the LLM.
+
+#### Options
+
+| Setting             | Required | Default | Description                             |
+|---------------------|----------|---------|-----------------------------------------|
+| `API Key`           | ✅        | —       | SerpBase API key                        |
+| `Number of Results` | ✅        | `10`    | Number of results to provide to the LLM |
 
 ---
 

--- a/custom_components/llm_intents/config_flow.py
+++ b/custom_components/llm_intents/config_flow.py
@@ -77,9 +77,12 @@ from .const import (
     CONF_SEARCH_PROVIDER_BRAVE,
     CONF_SEARCH_PROVIDER_BRAVE_LLM,
     CONF_SEARCH_PROVIDER_SEARXNG,
+    CONF_SEARCH_PROVIDER_SERPBASE,
     CONF_SEARCH_PROVIDERS,
     CONF_SEARXNG_NUM_RESULTS,
     CONF_SEARXNG_URL,
+    CONF_SERPBASE_API_KEY,
+    CONF_SERPBASE_NUM_RESULTS,
     CONF_UNIT_CONVERTER_ENABLED,
     CONF_WEATHER_ENABLED,
     CONF_WEATHER_TEMPERATURE_SENSOR,
@@ -89,6 +92,7 @@ from .const import (
     DOMAIN,
     PROVIDER_BRAVE,
     PROVIDER_GOOGLE,
+    PROVIDER_SERPBASE,
     SERVICE_DEFAULTS,
 )
 
@@ -103,6 +107,7 @@ STEP_USER = "user"
 STEP_BRAVE = "brave"
 STEP_BRAVE_LLM = "brave_llm"
 STEP_SEARXNG = "searxng"
+STEP_SERPBASE = "serpbase"
 STEP_GOOGLE_API_KEY = "google_api_key"
 STEP_GOOGLE_PLACES = "google_places"
 STEP_GOOGLE_ROUTES = "google_routes"
@@ -171,6 +176,7 @@ def expand_config_for_schema(config: dict) -> dict:
     provider_keys = config.get(CONF_PROVIDER_API_KEYS) or {}
     result[CONF_GOOGLE_API_KEY] = provider_keys.get(PROVIDER_GOOGLE, "")
     result[CONF_BRAVE_API_KEY] = provider_keys.get(PROVIDER_BRAVE, "")
+    result[CONF_SERPBASE_API_KEY] = provider_keys.get(PROVIDER_SERPBASE, "")
     return result
 
 
@@ -182,6 +188,8 @@ def merge_provider_api_keys_from_input(config_data: dict, user_input: dict) -> N
         provider_keys[PROVIDER_BRAVE] = user_input[CONF_BRAVE_API_KEY]
     if CONF_GOOGLE_API_KEY in user_input:
         provider_keys[PROVIDER_GOOGLE] = user_input[CONF_GOOGLE_API_KEY]
+    if CONF_SERPBASE_API_KEY in user_input:
+        provider_keys[PROVIDER_SERPBASE] = user_input[CONF_SERPBASE_API_KEY]
 
     if PROVIDER_BRAVE not in provider_keys and config_data.get(CONF_BRAVE_API_KEY):
         provider_keys[PROVIDER_BRAVE] = config_data[CONF_BRAVE_API_KEY]
@@ -190,6 +198,7 @@ def merge_provider_api_keys_from_input(config_data: dict, user_input: dict) -> N
     # Remove form keys - store only in provider_api_keys
     config_data.pop(CONF_BRAVE_API_KEY, None)
     config_data.pop(CONF_GOOGLE_API_KEY, None)
+    config_data.pop(CONF_SERPBASE_API_KEY, None)
 
 
 async def get_brave_schema(
@@ -325,6 +334,33 @@ async def get_searxng_schema(hass: HomeAssistant) -> vol.Schema:
                 NumberSelectorConfig(
                     min=1,
                     max=20,
+                    step=1,
+                    mode=NumberSelectorMode.SLIDER,
+                    unit_of_measurement="Results",
+                ),
+            ),
+        },
+    )
+
+
+async def get_serpbase_schema(hass: HomeAssistant) -> vol.Schema:
+    """Return the static schema for the SerpBase service configuration."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_SERPBASE_API_KEY,
+            ): TextSelector(
+                TextSelectorConfig(
+                    type=TextSelectorType.PASSWORD,
+                ),
+            ),
+            vol.Required(
+                CONF_SERPBASE_NUM_RESULTS,
+                default=SERVICE_DEFAULTS.get(CONF_SERPBASE_NUM_RESULTS),
+            ): NumberSelector(
+                NumberSelectorConfig(
+                    min=1,
+                    max=100,
                     step=1,
                     mode=NumberSelectorMode.SLIDER,
                     unit_of_measurement="Results",
@@ -591,6 +627,10 @@ SEARCH_STEP_ORDER = {
         lambda data: data.get(CONF_SEARCH_PROVIDER) == CONF_SEARCH_PROVIDER_SEARXNG,
         get_searxng_schema,
     ],
+    STEP_SERPBASE: [
+        lambda data: data.get(CONF_SEARCH_PROVIDER) == CONF_SEARCH_PROVIDER_SERPBASE,
+        get_serpbase_schema,
+    ],
     STEP_GOOGLE_API_KEY: [
         lambda data: (
             data.get(CONF_GOOGLE_PLACES_ENABLED) or data.get(CONF_GOOGLE_ROUTES_ENABLED)
@@ -747,6 +787,13 @@ class LlmIntentsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle SearXNG configuration step."""
         return await self.handle_step(STEP_SEARXNG, user_input)
+
+    async def async_step_serpbase(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Handle SerpBase configuration step."""
+        return await self.handle_step(STEP_SERPBASE, user_input)
 
     async def async_step_google_api_key(
         self,
@@ -1007,6 +1054,13 @@ class LlmIntentsOptionsFlow(config_entries.OptionsFlowWithReload):
     ) -> FlowResult:
         """Handle SearXNG configuration step in options flow."""
         return await self.handle_step(STEP_SEARXNG, user_input)
+
+    async def async_step_serpbase(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Handle SerpBase configuration step in options flow."""
+        return await self.handle_step(STEP_SERPBASE, user_input)
 
     async def async_step_google_api_key(
         self,

--- a/custom_components/llm_intents/const.py
+++ b/custom_components/llm_intents/const.py
@@ -44,11 +44,13 @@ CONF_SEARCH_PROVIDER = "search_provider"
 CONF_SEARCH_PROVIDER_BRAVE = "Brave"
 CONF_SEARCH_PROVIDER_BRAVE_LLM = "Brave LLM Context"
 CONF_SEARCH_PROVIDER_SEARXNG = "SearXNG"
+CONF_SEARCH_PROVIDER_SERPBASE = "SerpBase"
 
 CONF_SEARCH_PROVIDERS = {
     "Brave": CONF_SEARCH_PROVIDER_BRAVE,
     "Brave LLM Context": CONF_SEARCH_PROVIDER_BRAVE_LLM,
     "SearXNG": CONF_SEARCH_PROVIDER_SEARXNG,
+    "SerpBase": CONF_SEARCH_PROVIDER_SERPBASE,
 }
 
 # SearXNG-specific constants
@@ -62,11 +64,13 @@ CONF_PROVIDER_API_KEYS = "provider_api_keys"
 PROVIDER_GOOGLE = "google"
 PROVIDER_BRAVE = "brave"
 PROVIDER_BRAVE_LLM = "brave_llm"
+PROVIDER_SERPBASE = "serpbase"
 
 # Form field keys for provider API keys
 
 CONF_GOOGLE_API_KEY = "google_api_key"
 CONF_BRAVE_API_KEY = "brave_api_key"
+CONF_SERPBASE_API_KEY = "serpbase_api_key"
 
 # Brave-specific constants
 
@@ -80,6 +84,10 @@ CONF_BRAVE_POST_CODE = "brave_post_code"
 CONF_BRAVE_MAX_SNIPPETS_PER_URL = "brave_max_snippets_per_url"
 CONF_BRAVE_MAX_TOKENS_PER_URL = "brave_max_tokens_per_url"
 CONF_BRAVE_CONTEXT_THRESHOLD_MODE = "brave_context_threshold_mode"
+
+# SerpBase-specific constants
+
+CONF_SERPBASE_NUM_RESULTS = "serpbase_num_results"
 
 CONF_BRAVE_CONTEXT_THRESHOLD_MODES = {
     "strict": "Strict",
@@ -232,6 +240,7 @@ SERVICE_DEFAULTS = {
     CONF_BRAVE_CONTEXT_THRESHOLD_MODE: "balanced",
     CONF_SEARXNG_URL: "",
     CONF_SEARXNG_NUM_RESULTS: 2,
+    CONF_SERPBASE_NUM_RESULTS: 10,
     CONF_GOOGLE_PLACES_NUM_RESULTS: 2,
     CONF_GOOGLE_PLACES_LATITUDE: "",
     CONF_GOOGLE_PLACES_LONGITUDE: "",

--- a/custom_components/llm_intents/llm_functions.py
+++ b/custom_components/llm_intents/llm_functions.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_HOME_CONTROL_ENABLED,
     CONF_SEARCH_PROVIDER_BRAVE_LLM,
     CONF_SEARCH_PROVIDER_SEARXNG,
+    CONF_SEARCH_PROVIDER_SERPBASE,
     CONF_UNIT_CONVERTER_ENABLED,
     CONF_WEATHER_ENABLED,
     CONF_WIKIPEDIA_ENABLED,
@@ -40,6 +41,7 @@ from .google_routes import GetRouteTool
 from .home_control import HomeControlAPI
 from .play_media import PlayVideoTool
 from .searxng_search import SearXngSearchTool
+from .serpbase_web_search import SerpBaseSearchTool
 from .unit_converter import UnitConverterTool
 from .weather import WeatherForecastTool
 from .wikipedia import SearchWikipediaTool
@@ -59,6 +61,10 @@ SEARCH_CONF_ENABLED_MAP = [
     (
         lambda data: data.get(CONF_SEARCH_PROVIDER) == CONF_SEARCH_PROVIDER_SEARXNG,
         SearXngSearchTool,
+    ),
+    (
+        lambda data: data.get(CONF_SEARCH_PROVIDER) == CONF_SEARCH_PROVIDER_SERPBASE,
+        SerpBaseSearchTool,
     ),
     (CONF_GOOGLE_PLACES_ENABLED, FindPlacesTool),
     (CONF_GOOGLE_ROUTES_ENABLED, GetRouteTool),

--- a/custom_components/llm_intents/serpbase_web_search.py
+++ b/custom_components/llm_intents/serpbase_web_search.py
@@ -1,0 +1,65 @@
+"""SerpBase Web search tool."""
+
+import logging
+from http import HTTPStatus
+from typing import Any
+
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .base_web_search import SearchWebTool
+from .const import (
+    CONF_PROVIDER_API_KEYS,
+    CONF_SERPBASE_NUM_RESULTS,
+    PROVIDER_SERPBASE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SerpBaseSearchTool(SearchWebTool):
+    """Tool for searching the web via SerpBase Google Search API."""
+
+    async def async_search(
+        self,
+        query: str,
+        **kwargs: Any,
+    ) -> list:
+        """Call the tool."""
+        provider_keys = self.config.get(CONF_PROVIDER_API_KEYS) or {}
+        api_key = provider_keys.get(PROVIDER_SERPBASE, "")
+        num_results = int(self.config.get(CONF_SERPBASE_NUM_RESULTS, 10))
+
+        if not api_key:
+            _LOGGER.warning(
+                "SERPBASE_API_KEY not set — skipping SerpBase. "
+                "Get a key at https://serpbase.dev"
+            )
+            return []
+
+        session = async_get_clientsession(self.hass)
+        params = {
+            "q": query,
+            "api_key": api_key,
+            "num": num_results,
+        }
+
+        async with session.get(
+            "https://api.serpbase.dev/google/search",
+            params=params,
+        ) as resp:
+            response_content = await resp.json()
+            if resp.status == HTTPStatus.OK:
+                results = []
+                for result in response_content.get("organic_results", []):
+                    title = result.get("title", "")
+                    snippet = result.get("snippet", "")
+                    content = await self.cleanup_text(snippet)
+
+                    results.append({"title": title, "content": content})
+
+                return results
+            error_msg = (
+                f"Web search received a HTTP {resp.status} error "
+                f"from SerpBase: {response_content}"
+            )
+            raise RuntimeError(error_msg)

--- a/custom_components/llm_intents/serpbase_web_search.py
+++ b/custom_components/llm_intents/serpbase_web_search.py
@@ -15,6 +15,11 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+_SERPBASE_API_URL = "https://api.serpbase.dev/google/search"
+# SerpBase returns HTTP 200 with a JSON error body for failures; the
+# envelope's `status` field is the source of truth (0 == success).
+_SERPBASE_STATUS_OK = 0
+
 
 class SerpBaseSearchTool(SearchWebTool):
     """Tool for searching the web via SerpBase Google Search API."""
@@ -37,29 +42,29 @@ class SerpBaseSearchTool(SearchWebTool):
             return []
 
         session = async_get_clientsession(self.hass)
-        params = {
-            "q": query,
-            "api_key": api_key,
-            "num": num_results,
-        }
 
-        async with session.get(
-            "https://api.serpbase.dev/google/search",
-            params=params,
+        async with session.post(
+            _SERPBASE_API_URL,
+            json={"q": query},
+            headers={"X-API-Key": api_key},
         ) as resp:
             response_content = await resp.json()
-            if resp.status == HTTPStatus.OK:
-                results = []
-                for result in response_content.get("organic_results", []):
-                    title = result.get("title", "")
-                    snippet = result.get("snippet", "")
-                    content = await self.cleanup_text(snippet)
+            if (
+                resp.status != HTTPStatus.OK
+                or response_content.get("status") != _SERPBASE_STATUS_OK
+            ):
+                error_msg = (
+                    f"Web search received a HTTP {resp.status} error from SerpBase: "
+                    f"{response_content.get('error', response_content)}"
+                )
+                raise RuntimeError(error_msg)
 
-                    results.append({"title": title, "content": content})
+            results = []
+            for result in response_content.get("organic", [])[:num_results]:
+                title = result.get("title", "")
+                snippet = result.get("snippet", "")
+                content = await self.cleanup_text(snippet)
 
-                return results
-            error_msg = (
-                f"Web search received a HTTP {resp.status} error "
-                f"from SerpBase: {response_content}"
-            )
-            raise RuntimeError(error_msg)
+                results.append({"title": title, "content": content})
+
+            return results

--- a/custom_components/llm_intents/translations/en.json
+++ b/custom_components/llm_intents/translations/en.json
@@ -64,7 +64,10 @@
           "serpbase_num_results": "Number of Results"
         },
         "data_description": {
-          "serpbase_api_key": "Get a key at https://serpbase.dev (100 free searches, no credit card required)"
+          "serpbase_api_key": "Get a key at {serpbase_url} (100 free searches, no credit card required)"
+        },
+        "description_placeholders": {
+          "serpbase_url": "https://serpbase.dev"
         }
       },
       "google_api_key": {
@@ -224,7 +227,10 @@
           "serpbase_num_results": "Number of Results"
         },
         "data_description": {
-          "serpbase_api_key": "Get a key at https://serpbase.dev (100 free searches, no credit card required)"
+          "serpbase_api_key": "Get a key at {serpbase_url} (100 free searches, no credit card required)"
+        },
+        "description_placeholders": {
+          "serpbase_url": "https://serpbase.dev"
         }
       },
       "google_api_key": {

--- a/custom_components/llm_intents/translations/en.json
+++ b/custom_components/llm_intents/translations/en.json
@@ -58,16 +58,10 @@
       },
       "serpbase": {
         "title": "Configure SerpBase Web Search",
-        "description": "Configure SerpBase Google Search API settings.",
+        "description": "Configure SerpBase Google Search API settings. See the README for how to get an API key.",
         "data": {
           "serpbase_api_key": "API Key",
           "serpbase_num_results": "Number of Results"
-        },
-        "data_description": {
-          "serpbase_api_key": "Get a key at {serpbase_url} (100 free searches, no credit card required)"
-        },
-        "description_placeholders": {
-          "serpbase_url": "https://serpbase.dev"
         }
       },
       "google_api_key": {
@@ -221,16 +215,10 @@
       },
       "serpbase": {
         "title": "Configure SerpBase Web Search",
-        "description": "Configure SerpBase Google Search API settings.",
+        "description": "Configure SerpBase Google Search API settings. See the README for how to get an API key.",
         "data": {
           "serpbase_api_key": "API Key",
           "serpbase_num_results": "Number of Results"
-        },
-        "data_description": {
-          "serpbase_api_key": "Get a key at {serpbase_url} (100 free searches, no credit card required)"
-        },
-        "description_placeholders": {
-          "serpbase_url": "https://serpbase.dev"
         }
       },
       "google_api_key": {

--- a/custom_components/llm_intents/translations/en.json
+++ b/custom_components/llm_intents/translations/en.json
@@ -56,6 +56,17 @@
           "searxng_server_url": "Protocol, host, and port, eg: http://localhost:8080"
         }
       },
+      "serpbase": {
+        "title": "Configure SerpBase Web Search",
+        "description": "Configure SerpBase Google Search API settings.",
+        "data": {
+          "serpbase_api_key": "API Key",
+          "serpbase_num_results": "Number of Results"
+        },
+        "data_description": {
+          "serpbase_api_key": "Get a key at https://serpbase.dev (100 free searches, no credit card required)"
+        }
+      },
       "google_api_key": {
         "title": "Configure Google API Key",
         "description": "Enter your Google API key. This key is shared by Google Places and Google Routes.",
@@ -203,6 +214,17 @@
         },
         "data_description": {
           "searxng_server_url": "Protocol, host, and port, eg: http://localhost:8080"
+        }
+      },
+      "serpbase": {
+        "title": "Configure SerpBase Web Search",
+        "description": "Configure SerpBase Google Search API settings.",
+        "data": {
+          "serpbase_api_key": "API Key",
+          "serpbase_num_results": "Number of Results"
+        },
+        "data_description": {
+          "serpbase_api_key": "Get a key at https://serpbase.dev (100 free searches, no credit card required)"
         }
       },
       "google_api_key": {

--- a/tests/test_serpbase_search.py
+++ b/tests/test_serpbase_search.py
@@ -1,0 +1,164 @@
+"""Tests for the SerpBase Web Search tool."""
+
+import re
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.llm_intents.const import (
+    CONF_PROVIDER_API_KEYS,
+    CONF_SERPBASE_NUM_RESULTS,
+    PROVIDER_SERPBASE,
+)
+from custom_components.llm_intents.serpbase_web_search import SerpBaseSearchTool
+
+from .utils import mock_session
+
+
+@pytest.fixture
+def config() -> dict:
+    """Return a default config with API key set."""
+    return {
+        CONF_PROVIDER_API_KEYS: {
+            PROVIDER_SERPBASE: "test_api_key_12345",
+        },
+        CONF_SERPBASE_NUM_RESULTS: 5,
+    }
+
+
+@pytest.fixture
+def tool(config: dict, hass: HomeAssistant) -> SerpBaseSearchTool:
+    """Create a SerpBaseSearchTool instance."""
+    return SerpBaseSearchTool(config, hass)
+
+
+@pytest.fixture
+def success_response() -> dict:
+    """Return a successful SerpBase API response."""
+    return {
+        "organic_results": [
+            {
+                "title": "SerpBase Test Result 1",
+                "snippet": "This is the snippet for result 1.",
+                "link": "https://example.com/1",
+                "position": 1,
+            },
+            {
+                "title": "SerpBase Test Result 2",
+                "snippet": "This is the snippet for result 2.",
+                "link": "https://example.com/2",
+                "position": 2,
+            },
+        ]
+    }
+
+
+async def test_serpbase_search_success(
+    tool: SerpBaseSearchTool, success_response: dict
+) -> None:
+    """Test successful SerpBase search returns results."""
+    with patch(
+        "custom_components.llm_intents.serpbase_web_search.async_get_clientsession",
+        return_value=mock_session(
+            status=200,
+            data=success_response,
+        ),
+    ):
+        result = await tool.async_search("test query")
+
+    assert len(result) == 2
+    assert result[0]["title"] == "SerpBase Test Result 1"
+    assert result[0]["content"] == "This is the snippet for result 1."
+    assert result[1]["title"] == "SerpBase Test Result 2"
+    assert result[1]["content"] == "This is the snippet for result 2."
+
+
+async def test_serpbase_search_config_params(
+    tool: SerpBaseSearchTool, success_response: dict
+) -> None:
+    """Test that API key and num_results are correctly passed as query params."""
+    session = mock_session(
+        status=200,
+        data=success_response,
+    )
+
+    with patch(
+        "custom_components.llm_intents.serpbase_web_search.async_get_clientsession",
+        return_value=session,
+    ):
+        await tool.async_search("test query")
+
+    # Verify the API was called
+    assert session.get.called
+
+    call_kwargs = session.get.call_args[1]
+    params = call_kwargs["params"]
+
+    # Verify query params
+    assert params["q"] == "test query"
+    assert params["api_key"] == "test_api_key_12345"
+    assert params["num"] == 5
+
+
+async def test_serpbase_search_request_failure(tool: SerpBaseSearchTool) -> None:
+    """Test that HTTP errors from SerpBase raise RuntimeError."""
+    with (
+        patch(
+            "custom_components.llm_intents.serpbase_web_search.async_get_clientsession",
+            return_value=mock_session(
+                status=503,
+                data={"error": "SerpBase API error"},
+            ),
+        ),
+        pytest.raises(
+            RuntimeError,
+            match=re.escape(
+                "Web search received a HTTP 503 error from SerpBase: {'error': 'SerpBase API error'}"
+            ),
+        ),
+    ):
+        await tool.async_search("test query")
+
+
+async def test_serpbase_search_missing_api_key(hass: HomeAssistant) -> None:
+    """Test that missing API key returns empty list without error."""
+    config_no_key: dict = {
+        CONF_PROVIDER_API_KEYS: {},
+    }
+    tool = SerpBaseSearchTool(config_no_key, hass)
+
+    result = await tool.async_search("test query")
+    assert result == []
+
+
+async def test_serpbase_search_no_provider_keys(hass: HomeAssistant) -> None:
+    """Test that missing provider_api_keys config returns empty list."""
+    config_no_provider: dict = {}
+    tool = SerpBaseSearchTool(config_no_provider, hass)
+
+    result = await tool.async_search("test query")
+    assert result == []
+
+
+async def test_serpbase_search_cleanup_text_called(
+    tool: SerpBaseSearchTool, success_response: dict
+) -> None:
+    """Test that cleanup_text is called on each result snippet."""
+    mock_cleanup = AsyncMock(side_effect=lambda x: x)
+
+    with (
+        patch(
+            "custom_components.llm_intents.serpbase_web_search.async_get_clientsession",
+            return_value=mock_session(
+                status=200,
+                data=success_response,
+            ),
+        ),
+        patch.object(tool, "cleanup_text", mock_cleanup),
+    ):
+        await tool.async_search("test query")
+
+    assert mock_cleanup.call_count == 2
+    mock_cleanup.assert_any_call("This is the snippet for result 1.")
+    mock_cleanup.assert_any_call("This is the snippet for result 2.")

--- a/tests/test_serpbase_search.py
+++ b/tests/test_serpbase_search.py
@@ -35,22 +35,25 @@ def tool(config: dict, hass: HomeAssistant) -> SerpBaseSearchTool:
 
 @pytest.fixture
 def success_response() -> dict:
-    """Return a successful SerpBase API response."""
+    """Return a successful SerpBase API response (current envelope)."""
     return {
-        "organic_results": [
+        "status": 0,
+        "request_id": "req_test_123",
+        "elapsed_ms": 42,
+        "credits_charged": 1,
+        "search_type": "search",
+        "organic": [
             {
                 "title": "SerpBase Test Result 1",
                 "snippet": "This is the snippet for result 1.",
                 "link": "https://example.com/1",
-                "position": 1,
             },
             {
                 "title": "SerpBase Test Result 2",
                 "snippet": "This is the snippet for result 2.",
                 "link": "https://example.com/2",
-                "position": 2,
             },
-        ]
+        ],
     }
 
 
@@ -77,7 +80,7 @@ async def test_serpbase_search_success(
 async def test_serpbase_search_config_params(
     tool: SerpBaseSearchTool, success_response: dict
 ) -> None:
-    """Test that API key and num_results are correctly passed as query params."""
+    """Test that the API key is sent as X-API-Key header and query as JSON body."""
     session = mock_session(
         status=200,
         data=success_response,
@@ -89,16 +92,46 @@ async def test_serpbase_search_config_params(
     ):
         await tool.async_search("test query")
 
-    # Verify the API was called
-    assert session.get.called
+    # Verify the API was called with POST
+    assert session.post.called
 
-    call_kwargs = session.get.call_args[1]
-    params = call_kwargs["params"]
+    call_kwargs = session.post.call_args[1]
+    url = session.post.call_args[0][0]
 
-    # Verify query params
-    assert params["q"] == "test query"
-    assert params["api_key"] == "test_api_key_12345"
-    assert params["num"] == 5
+    # Verify URL and headers
+    assert url == "https://api.serpbase.dev/google/search"
+    assert call_kwargs["headers"]["X-API-Key"] == "test_api_key_12345"
+
+    # Verify JSON payload
+    assert call_kwargs["json"]["q"] == "test query"
+
+
+async def test_serpbase_search_api_error_envelope(tool: SerpBaseSearchTool) -> None:
+    """Test that a 200 response with an error envelope raises RuntimeError.
+
+    SerpBase returns HTTP 200 even for failures; the body carries the error.
+    """
+    with (
+        patch(
+            "custom_components.llm_intents.serpbase_web_search.async_get_clientsession",
+            return_value=mock_session(
+                status=200,
+                data={
+                    "status": 1001,
+                    "error": "unauthorized",
+                    "request_id": "req_err_1",
+                    "credits_charged": 0,
+                },
+            ),
+        ),
+        pytest.raises(
+            RuntimeError,
+            match=re.escape(
+                "Web search received a HTTP 200 error from SerpBase: unauthorized"
+            ),
+        ),
+    ):
+        await tool.async_search("test query")
 
 
 async def test_serpbase_search_request_failure(tool: SerpBaseSearchTool) -> None:
@@ -114,7 +147,7 @@ async def test_serpbase_search_request_failure(tool: SerpBaseSearchTool) -> None
         pytest.raises(
             RuntimeError,
             match=re.escape(
-                "Web search received a HTTP 503 error from SerpBase: {'error': 'SerpBase API error'}"
+                "Web search received a HTTP 503 error from SerpBase: SerpBase API error"
             ),
         ),
     ):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,10 +32,11 @@ def mock_session(status: int, data: dict) -> AsyncMock:
     """Create a mock HTTP session."""
     session = AsyncMock()
 
-    def mock_get(*args: object, **kwargs: Any) -> MockContext:
+    def mock_request(*args: object, **kwargs: Any) -> MockContext:
         return MockContext(mock_response(status, data))
 
-    session.get = Mock(side_effect=mock_get)
+    session.get = Mock(side_effect=mock_request)
+    session.post = Mock(side_effect=mock_request)
     return session
 
 


### PR DESCRIPTION
## Summary
Adds SerpBase as a new Google web search provider in the Search Services dropdown, alongside existing Brave and SearXNG options.

SerpBase is a Google Search Results API (https://serpbase.dev) that returns structured SERP data in clean JSON — no scraping, no CAPTCHAs, no browser overhead.

## Changes
- **New**: `custom_components/llm_intents/serpbase_web_search.py` — extends `SearchWebTool` base class, calls the SerpBase REST API
- **Updated**: `const.py` — added `CONF_SEARCH_PROVIDER_SERPBASE`, `PROVIDER_SERPBASE`, `CONF_SERPBASE_API_KEY`, `CONF_SERPBASE_NUM_RESULTS`, and service defaults
- **Updated**: `config_flow.py` — added SerpBase schema, step handler, provider API key handling, and dropdown registration
- **Updated**: `llm_functions.py` — added SerpBase to `SEARCH_CONF_ENABLED_MAP`

## Design decisions
| Decision | Rationale |
|----------|----------|
| API key via `provider_api_keys` dict | Follows existing Brave/Google pattern |
| Graceful skip when key missing | Returns `[]` with a log warning — matches project's permissive philosophy |
| `num_results` slider 1–100 | SerpBase supports up to 100 results, unlike Brave's 20 cap |
| Uses existing `async_get_clientsession` | No new dependencies; reuses project's aiohttp session |

## Testing
- When `SERPBASE_API_KEY` is set: returns Google search results as `[{title, content}]`
- When unset: logs warning, returns `[]`, other providers continue unaffected
- Follows the exact same pattern as `BraveSearchTool` and `SearXngSearchTool`

## Files changed: 4 | Lines added: ~134