### PR TITLE
Entity History tool bugfixes

### DIFF
--- a/custom_components/llm_intents/entity_history.py
+++ b/custom_components/llm_intents/entity_history.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant.components import recorder
+from homeassistant.components.homeassistant.llm import async_get_exposed_entities
 from homeassistant.components.recorder import history
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
@@ -63,6 +64,7 @@ class EntityHistoryTool(BaseTool):
         "- If the user wants to know the device state at an exact time, limit the start and end date/time arguments to exactly that date and time.\n"
         "- If the user wants information for a particular time period, such as the morning, evening, or overnight, ensure that the start and end times encapsulate the entire duration.\n"
         "- If the user wants to know the last time something changed, ensure to use the current date and time as the search end time.\n"
+        "- If the user wants to know when a person left or arrived home.\n"
         "Example queries: `What time did the kitchen reach 25 degrees?` `When was the bedroom light turned off?` `What was the temperature outside at 8am this morning?`"
     )
     prompt_description = None
@@ -70,8 +72,16 @@ class EntityHistoryTool(BaseTool):
     parameters = vol.Schema(
         {
             vol.Required(
-                "entity_name",
-                description="The name of the entity or device to retrieve the history for, exactly as it appears in the static device context.",
+                "name",
+                description="The name of the entity or device to retrieve the history for, exactly as it appears in the static device context (case-insensitive).",
+            ): str,
+            vol.Required(
+                "area",
+                description="Filter entities by area name or alias (case-insensitive).",
+            ): str,
+            vol.Required(
+                "domain",
+                description="Filter entities by the domain of the entity.",
             ): str,
             vol.Required(
                 "end_date_time",
@@ -190,11 +200,27 @@ class EntityHistoryTool(BaseTool):
         llm_context: llm.LLMContext,
     ) -> JsonObjectType:
         """Return state change history of the device entity."""
-        entity_name = tool_input.tool_args.get("entity_name").lower().strip()
+        entity_name = tool_input.tool_args.get("name")
+        area = tool_input.tool_args.get("area")
+        domain = tool_input.tool_args.get("domain")
         start_time = tool_input.tool_args.get("start_date_time")
         end_time = tool_input.tool_args.get("end_date_time")
 
-        entity = find_entity_by_name(hass, entity_name)
+        if not llm_context.assistant:
+            err_msg = "No assistant context available for entity history"
+            raise HomeAssistantError(err_msg)
+
+        exposed_entities = async_get_exposed_entities(
+            hass, llm_context.assistant, include_state=False
+        )
+
+        entity = find_entity_by_name(
+            hass,
+            entity_name,
+            exposed_entities=exposed_entities,
+            area=area,
+            domain=domain,
+        )
         entity_id = entity.entity_id
 
         start_time = _to_datetime(start_time)

--- a/custom_components/llm_intents/utils.py
+++ b/custom_components/llm_intents/utils.py
@@ -1,5 +1,7 @@
 """Utility functions for entity lookups."""
 
+from typing import Any
+
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -10,11 +12,37 @@ class EntityNotFoundError(HomeAssistantError):
     """Exception raised when an entity is not found."""
 
 
-def find_entity_by_name(hass: HomeAssistant, entity_name: str) -> State:
+def find_entity_by_name(
+    hass: HomeAssistant,
+    entity_name: str,
+    area: str,
+    domain: str,
+    *,
+    exposed_entities: dict[str, dict[str, Any]],
+) -> State:
     """Find an entity by its name or aliases."""
     entity_name_norm = entity_name.lower().strip()
+    area = area.lower().strip()
+    domain = domain.lower().strip()
 
     for state in hass.states.async_all():
+        # Exposed entities filter
+        if state.entity_id not in exposed_entities:
+            continue
+
+        # Domain filter
+        if state.domain != domain:
+            continue
+
+        # Area filter
+        entity_info = exposed_entities[state.entity_id]
+        entity_areas = entity_info.get("areas")
+        if entity_areas:
+            area_list = [a.lower().strip() for a in entity_areas.split(", ")]
+            if area not in area_list:
+                continue
+
+        # Name matching
         entity_entry = er.async_get(hass).async_get(state.entity_id)
         names = intent.async_get_entity_aliases(hass, entity_entry, state=state)
         check_names = [state.entity_id, *names]

--- a/tests/config_flow/test_home_control_options.py
+++ b/tests/config_flow/test_home_control_options.py
@@ -1,0 +1,64 @@
+"""Tests for the Home Control options flow."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.llm_intents.config_flow import LlmIntentsOptionsFlow
+from custom_components.llm_intents.const import (
+    CONF_HOME_CONTROL_DISABLED_TOOLS,
+    CONF_HOME_CONTROL_ENABLED,
+    DOMAIN,
+)
+
+
+@pytest.fixture
+def config_entry() -> MockConfigEntry:
+    """Mock ConfigEntry with home control settings including a stale disabled tool."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_home_control_options_entry",
+        data={"some_config": "value"},
+        options={
+            CONF_HOME_CONTROL_ENABLED: True,
+            CONF_HOME_CONTROL_DISABLED_TOOLS: ["HassTurnOn", "NonExistentTool"],
+        },
+    )
+
+
+async def test_async_step_home_control_filters_stale_disabled_tools(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that stale disabled tools are filtered out before suggesting values."""
+    config_entry.add_to_hass(hass)
+
+    flow = LlmIntentsOptionsFlow(config_entry)
+    flow.hass = hass
+
+    mock_tool = MagicMock()
+    mock_tool.name = "HassTurnOn"
+
+    with patch(
+        "custom_components.llm_intents.config_flow.enumerate_tools",
+        AsyncMock(return_value=[mock_tool]),
+    ):
+        result = await flow.async_step_home_control()
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "home_control"
+    data_schema = result["data_schema"]
+
+    # Find the disabled_tools key in the schema
+    disabled_tools_key = None
+    for key in data_schema.schema:
+        if hasattr(key, "schema") and key.schema == CONF_HOME_CONTROL_DISABLED_TOOLS:
+            disabled_tools_key = key
+            break
+
+    assert disabled_tools_key is not None
+    suggested = disabled_tools_key.description.get("suggested_value")
+    assert suggested == ["HassTurnOn"]
+    assert "NonExistentTool" not in suggested

--- a/tests/test_entity_history.py
+++ b/tests/test_entity_history.py
@@ -12,6 +12,7 @@ from custom_components.llm_intents.entity_history import (
     EntityHistoryTool,
     _state_value,
 )
+from custom_components.llm_intents.utils import EntityNotFoundError
 
 
 def _make_states(
@@ -45,6 +46,10 @@ def mock_recorder() -> tuple[MagicMock, MagicMock]:
         patch(
             "custom_components.llm_intents.entity_history.recorder.get_instance",
         ) as mock_get_instance,
+        patch(
+            "custom_components.llm_intents.entity_history.async_get_exposed_entities",
+            new=AsyncMock(return_value={}),
+        ),
     ):
         mock_session = MagicMock()
         mock_scope.return_value.__enter__.return_value = mock_session
@@ -75,6 +80,14 @@ def mock_recorder() -> tuple[MagicMock, MagicMock]:
             6,
             True,
         ),
+        # Non-numeric entity: skips numeric stats but caps results
+        (
+            50,
+            lambda i: "on" if i % 2 == 0 else "off",
+            MAX_HISTORY_RESULTS,
+            50,
+            False,
+        ),
     ],
 )
 async def test_downsampling_behavior(
@@ -86,7 +99,7 @@ async def test_downsampling_behavior(
     expected_total: int,
     expect_numeric_stats: bool,
 ) -> None:
-    """Test downsampling with high-frequency and low-frequency entities."""
+    """Test downsampling with high-frequency, low-frequency, and non-numeric entities."""
     mock_find, mock_get_instance = mock_recorder
     entity_id = "sensor.temperature"
     mock_find.return_value = State(entity_id, "22.0")
@@ -103,7 +116,9 @@ async def test_downsampling_behavior(
         hass,
         MagicMock(
             tool_args={
-                "entity_name": "Temperature",
+                "name": "Temperature",
+                "area": "Kitchen",
+                "domain": "sensor",
                 "start_date_time": "2024-01-15 00:00",
                 "end_date_time": "2024-01-15 23:59",
             }
@@ -121,99 +136,6 @@ async def test_downsampling_behavior(
         assert "min" not in result["stats"]
         assert "max" not in result["stats"]
         assert "avg" not in result["stats"]
-
-
-async def test_downsample_preserves_min_max_and_order(
-    mock_recorder: tuple[MagicMock, MagicMock],
-    hass: HomeAssistant,
-) -> None:
-    """Test downsampling preserves min/max values and chronological order."""
-    mock_find, mock_get_instance = mock_recorder
-    entity_id = "sensor.with_spike"
-    mock_find.return_value = State(entity_id, "20.0")
-
-    base_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
-    values = [20.0] * 50 + [35.0] + [21.0] * 49
-    states = _make_states(
-        entity_id,
-        100,
-        base_time,
-        lambda i: str(values[i]),
-    )
-
-    mock_get_instance.return_value.async_add_executor_job = AsyncMock(
-        return_value={entity_id: states},
-    )
-
-    tool = EntityHistoryTool({}, hass)
-    result = await tool.async_call(
-        hass,
-        MagicMock(
-            tool_args={
-                "entity_name": "Sensor With Spike",
-                "start_date_time": "2024-01-15 00:00",
-                "end_date_time": "2024-01-15 23:59",
-            }
-        ),
-        MagicMock(),
-    )
-
-    assert result["stats"]["min"] == 20.0
-    assert result["stats"]["max"] == 35.0
-    sampled_states = [s["state"] for s in result["sampled_states"]]
-    assert "35.0" in sampled_states
-    timestamps = [s["last_changed"] for s in result["sampled_states"]]
-    assert timestamps == sorted(timestamps), (
-        "sampled_states must be in chronological order"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Integration tests — non-numeric entity
-# ---------------------------------------------------------------------------
-
-
-async def test_non_numeric_entity(
-    mock_recorder: tuple[MagicMock, MagicMock],
-    hass: HomeAssistant,
-) -> None:
-    """Test non-numeric entity skips numeric stats but caps results."""
-    mock_find, mock_get_instance = mock_recorder
-    entity_id = "switch.living_room_light"
-    mock_find.return_value = State(entity_id, "off")
-
-    base_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
-    states = _make_states(
-        entity_id,
-        50,
-        base_time,
-        lambda i: "on" if i % 2 == 0 else "off",
-    )
-
-    mock_get_instance.return_value.async_add_executor_job = AsyncMock(
-        return_value={entity_id: states},
-    )
-
-    tool = EntityHistoryTool({}, hass)
-    result = await tool.async_call(
-        hass,
-        MagicMock(
-            tool_args={
-                "entity_name": "Living Room Light",
-                "start_date_time": "2024-01-15 00:00",
-                "end_date_time": "2024-01-15 23:59",
-            }
-        ),
-        MagicMock(),
-    )
-
-    assert len(result["sampled_states"]) == MAX_HISTORY_RESULTS
-    assert "min" not in result["stats"]
-    assert "max" not in result["stats"]
-    assert "avg" not in result["stats"]
-    assert result["stats"]["total_data_points"] == 50
-    assert "state_at_search_start" in result["stats"]
-    assert "state_at_end" in result["stats"]
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +164,19 @@ async def test_non_numeric_entity(
             [],
             True,
         ),
+        # Start available, end unavailable → empty result with both states
+        (
+            "22.0",
+            [
+                State("sensor.test", "22.0", last_changed=datetime.now(UTC)),
+                State(
+                    "sensor.test",
+                    "unavailable",
+                    last_changed=datetime.now(UTC) + timedelta(seconds=18),
+                ),
+            ],
+            False,
+        ),
     ],
 )
 async def test_early_return_no_sampled_states(
@@ -265,7 +200,9 @@ async def test_early_return_no_sampled_states(
         hass,
         MagicMock(
             tool_args={
-                "entity_name": "Test",
+                "name": "Test",
+                "area": "Kitchen",
+                "domain": "sensor",
                 "start_date_time": "2024-01-15 00:00",
                 "end_date_time": "2024-01-15 23:59",
             }
@@ -279,49 +216,8 @@ async def test_early_return_no_sampled_states(
         assert "stats" in result
         assert "sampled_states" not in result
         assert result["stats"]["state_at_search_start"] == state_value
-
-
-async def test_state_at_end_reports_unavailable(
-    mock_recorder: tuple[MagicMock, MagicMock],
-    hass: HomeAssistant,
-) -> None:
-    """Test state_at_end reports the true last state even when it went unavailable."""
-    mock_find, mock_get_instance = mock_recorder
-    entity_id = "sensor.went_down"
-    mock_find.return_value = State(entity_id, "22.0")
-
-    base_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
-    start = State(
-        entity_id,
-        "22.0",
-        last_changed=base_time,
-        last_updated=base_time,
-    )
-    gone = State(
-        entity_id,
-        "unavailable",
-        last_changed=base_time + timedelta(seconds=18),
-        last_updated=base_time + timedelta(seconds=18),
-    )
-    mock_get_instance.return_value.async_add_executor_job = AsyncMock(
-        return_value={entity_id: [start, gone]},
-    )
-
-    tool = EntityHistoryTool({}, hass)
-    result = await tool.async_call(
-        hass,
-        MagicMock(
-            tool_args={
-                "entity_name": "Went Down",
-                "start_date_time": "2024-01-15 00:00",
-                "end_date_time": "2024-01-15 23:59",
-            }
-        ),
-        MagicMock(),
-    )
-
-    assert result["stats"]["state_at_search_start"] == "22.0"
-    assert result["stats"]["state_at_end"] == "unavailable"
+        if state_value == "22.0":
+            assert result["stats"]["state_at_end"] == "unavailable"
 
 
 # ---------------------------------------------------------------------------
@@ -376,7 +272,9 @@ async def test_type_handling(
         hass,
         MagicMock(
             tool_args={
-                "entity_name": "Temp",
+                "name": "Temp",
+                "area": "Kitchen",
+                "domain": "sensor",
                 "start_date_time": "2024-01-15 00:00",
                 "end_date_time": "2024-01-15 23:59",
             }
@@ -682,3 +580,46 @@ def test_downsample_preserves_extremes() -> None:
     assert min(result_values) == 10.0
     assert max(result_values) == 30.0
     assert len(result) <= 30
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — area/domain filtering
+# ---------------------------------------------------------------------------
+
+
+async def test_async_call_ignores_non_exposed_entity(
+    hass: HomeAssistant,
+) -> None:
+    """Test that non-exposed entities raise EntityNotFoundError."""
+    hass.states.async_set("sensor.temperature", "22.0")
+    hass.states.async_set("light.living_room", "on")
+
+    exposed_entities = {
+        "light.living_room": {
+            "names": "Living Room Light",
+            "domain": "light",
+            "areas": "Living Room",
+        },
+    }
+
+    tool = EntityHistoryTool({}, hass)
+    with (
+        patch(
+            "custom_components.llm_intents.entity_history.async_get_exposed_entities",
+            return_value=exposed_entities,
+        ),
+        pytest.raises(EntityNotFoundError),
+    ):
+        await tool.async_call(
+            hass,
+            MagicMock(
+                tool_args={
+                    "name": "Temperature",
+                    "area": "Kitchen",
+                    "domain": "sensor",
+                    "start_date_time": "2024-01-15 00:00",
+                    "end_date_time": "2024-01-15 23:59",
+                }
+            ),
+            MagicMock(assistant="test_assistant"),
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,9 +18,12 @@ def hass_with_entities(hass: HomeAssistant) -> HomeAssistant:
     ]
 
     class MockEntry:
-        def __init__(self, entity_id: str, aliases: list[str]) -> None:
+        def __init__(
+            self, entity_id: str, aliases: list[str], area_id: str | None = None
+        ) -> None:
             self.entity_id = entity_id
             self.aliases = aliases
+            self.area_id = area_id
 
     registry = {
         "light.living_room": MockEntry(
@@ -53,57 +56,85 @@ def hass_with_entities(hass: HomeAssistant) -> HomeAssistant:
             yield hass
 
 
-def test_find_by_entity_id(hass_with_entities: HomeAssistant) -> None:
-    """Test finding an entity by its full entity_id."""
-    result = find_entity_by_name(hass_with_entities, "light.living_room")
-    assert result.entity_id == "light.living_room"
-    assert result.state == "on"
+_EXPOSED_ENTITIES = {
+    "light.living_room": {
+        "names": "Living Room Light",
+        "domain": "light",
+        "areas": "Living Room",
+    },
+    "sensor.kitchen_temperature": {
+        "names": "Kitchen Temperature",
+        "domain": "sensor",
+        "areas": "Kitchen",
+    },
+    "switch.garage_door": {
+        "names": "Garage Door",
+        "domain": "switch",
+        "areas": "Garage",
+    },
+}
 
 
-def test_find_by_human_name(hass_with_entities: HomeAssistant) -> None:
-    """Test finding an entity by its human-readable name."""
-    result = find_entity_by_name(hass_with_entities, "Living Room Light")
-    assert result.entity_id == "light.living_room"
-    assert result.state == "on"
+@pytest.mark.parametrize(
+    ("search_term", "area", "domain", "expected_entity_id", "expected_state"),
+    [
+        ("Living Room Light", "Living Room", "light", "light.living_room", "on"),
+        ("Living Room", "Living Room", "light", "light.living_room", "on"),
+        ("LIVING ROOM LIGHT", "Living Room", "light", "light.living_room", "on"),
+        ("living room light", "Living Room", "light", "light.living_room", "on"),
+        ("LiViNg RoOm LiGhT", "Living Room", "light", "light.living_room", "on"),
+        ("  Living Room Light  ", "Living Room", "light", "light.living_room", "on"),
+        (
+            "\tKitchen Temperature\n",
+            "Kitchen",
+            "sensor",
+            "sensor.kitchen_temperature",
+            "22.0",
+        ),
+    ],
+)
+def test_find_success(
+    hass_with_entities: HomeAssistant,
+    search_term: str,
+    area: str,
+    domain: str,
+    expected_entity_id: str,
+    expected_state: str,
+) -> None:
+    """Test finding an entity by human name, alias, case variations, and whitespace."""
+    result = find_entity_by_name(
+        hass_with_entities,
+        search_term,
+        area=area,
+        domain=domain,
+        exposed_entities=_EXPOSED_ENTITIES,
+    )
+    assert result.entity_id == expected_entity_id
+    assert result.state == expected_state
 
 
-def test_find_by_alias(hass_with_entities: HomeAssistant) -> None:
-    """Test finding an entity by one of its aliases."""
-    result = find_entity_by_name(hass_with_entities, "Living Room")
-    assert result.entity_id == "light.living_room"
-
-
-def test_find_case_insensitive(hass_with_entities: HomeAssistant) -> None:
-    """Test that entity name matching is case-insensitive."""
-    result = find_entity_by_name(hass_with_entities, "LIVING ROOM LIGHT")
-    assert result.entity_id == "light.living_room"
-
-    result = find_entity_by_name(hass_with_entities, "living room light")
-    assert result.entity_id == "light.living_room"
-
-    result = find_entity_by_name(hass_with_entities, "LiViNg RoOm LiGhT")
-    assert result.entity_id == "light.living_room"
-
-
-def test_find_whitespace_stripped(hass_with_entities: HomeAssistant) -> None:
-    """Test that leading/trailing whitespace is stripped from the search term."""
-    result = find_entity_by_name(hass_with_entities, "  Living Room Light  ")
-    assert result.entity_id == "light.living_room"
-
-    result = find_entity_by_name(hass_with_entities, "\tKitchen Temperature\n")
-    assert result.entity_id == "sensor.kitchen_temperature"
-
-
-def test_find_not_found_raises(hass_with_entities: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("search_term", "area", "domain"),
+    [
+        ("nonexistent_entity", "", ""),
+        ("nonexistent_entity", "Living Room", "light"),
+    ],
+)
+def test_find_not_found_raises(
+    hass_with_entities: HomeAssistant,
+    search_term: str,
+    area: str,
+    domain: str,
+) -> None:
     """Test that EntityNotFoundError is raised when no entity matches."""
     with pytest.raises(EntityNotFoundError):
-        find_entity_by_name(hass_with_entities, "nonexistent_entity")
-
-
-def test_find_not_found_case_insensitive(hass_with_entities: HomeAssistant) -> None:
-    """Test that EntityNotFoundError is raised even with different casing."""
-    with pytest.raises(EntityNotFoundError):
-        find_entity_by_name(hass_with_entities, "NonExistent")
+        find_entity_by_name(
+            hass_with_entities,
+            search_term,
+            area=area,
+            domain=domain,
+            exposed_entities=_EXPOSED_ENTITIES,
+        )
 
 
 def test_find_no_entity_entry() -> None:
@@ -122,13 +153,87 @@ def test_find_no_entity_entry() -> None:
         mock_get.return_value.async_get.return_value = None
         mock_aliases.return_value = []
 
-        result = find_entity_by_name(hass, "light.unknown_entity")
+        result = find_entity_by_name(
+            hass,
+            "light.unknown_entity",
+            area="",
+            domain="light",
+            exposed_entities={"light.unknown_entity": {"domain": "light"}},
+        )
         assert result.entity_id == "light.unknown_entity"
         assert result.state == "on"
 
 
-def test_find_multiple_entities_same_state(hass_with_entities: HomeAssistant) -> None:
-    """Test that the first matching entity is returned."""
-    result = find_entity_by_name(hass_with_entities, "Kitchen Temperature")
-    assert result.entity_id == "sensor.kitchen_temperature"
-    assert result.state == "22.0"
+@pytest.mark.parametrize(
+    ("search_term", "area", "domain", "exposed", "expect_error"),
+    [
+        # Domain match
+        ("light.living_room", "Living Room", "light", _EXPOSED_ENTITIES, False),
+        # Domain mismatch
+        ("light.living_room", "Living Room", "sensor", _EXPOSED_ENTITIES, True),
+        # Area mismatch
+        ("light.living_room", "Kitchen", "light", _EXPOSED_ENTITIES, True),
+        # Exposed entities filter: entity not in dict
+        (
+            "light.living_room",
+            "Living Room",
+            "light",
+            {
+                "light.living_room": {
+                    "names": "Living Room Light",
+                    "domain": "light",
+                    "areas": "Living Room",
+                },
+            },
+            False,
+        ),
+        (
+            "sensor.kitchen_temperature",
+            "Kitchen",
+            "sensor",
+            {
+                "light.living_room": {
+                    "names": "Living Room Light",
+                    "domain": "light",
+                    "areas": "Living Room",
+                },
+            },
+            True,
+        ),
+        # Filtered out entirely
+        (
+            "sensor.kitchen_temperature",
+            "Living Room",
+            "sensor",
+            _EXPOSED_ENTITIES,
+            True,
+        ),
+    ],
+)
+def test_find_filters(
+    hass_with_entities: HomeAssistant,
+    search_term: str,
+    area: str,
+    domain: str,
+    exposed: dict,
+    expect_error: bool,
+) -> None:
+    """Test domain, area, and exposed_entities filtering."""
+    if expect_error:
+        with pytest.raises(EntityNotFoundError):
+            find_entity_by_name(
+                hass_with_entities,
+                search_term,
+                area=area,
+                domain=domain,
+                exposed_entities=exposed,
+            )
+    else:
+        result = find_entity_by_name(
+            hass_with_entities,
+            search_term,
+            area=area,
+            domain=domain,
+            exposed_entities=exposed,
+        )
+        assert result is not None


### PR DESCRIPTION
Only match against exposed entities
Rename entity name arg, add area and domain args
- Mark all as required: we want to identify a singular entity for this tool, and all this info is available in default Assist context

Add test file missed in prior tool commit/release :) :)