### PR TITLE
Encapsulate aliases in backticks

### DIFF
--- a/custom_components/llm_intents/const.py
+++ b/custom_components/llm_intents/const.py
@@ -196,7 +196,7 @@ For general knowledge questions not about the home: Answer truthfully from inter
 {% if exposed_entities -%}
 Static Context: An overview of the areas and the devices in this smart home:
 {%- for entity in exposed_entities %}
-  {{- "\n- names: " + entity.names }}
+  {{- "\n- names: " + '`' + entity.names.split(',') | map('trim') | join('`, `') + '`' }}
   {%- for key, value in entity.items() %}
     {%- if key != 'names' %}
       {{- "\n  " + key + ": " + value }}

--- a/custom_components/llm_intents/entity_history.py
+++ b/custom_components/llm_intents/entity_history.py
@@ -75,13 +75,13 @@ class EntityHistoryTool(BaseTool):
                 "name",
                 description="The name of the entity or device to retrieve the history for, exactly as it appears in the static device context (case-insensitive).",
             ): str,
-            vol.Required(
+            vol.Optional(
                 "area",
-                description="Filter entities by area name or alias (case-insensitive).",
+                description="Filter entity by area name or alias (case-insensitive).",
             ): str,
             vol.Required(
                 "domain",
-                description="Filter entities by the domain of the entity.",
+                description="Filter entity by the domain (case-insensitive).",
             ): str,
             vol.Required(
                 "end_date_time",

--- a/custom_components/llm_intents/utils.py
+++ b/custom_components/llm_intents/utils.py
@@ -15,14 +15,13 @@ class EntityNotFoundError(HomeAssistantError):
 def find_entity_by_name(
     hass: HomeAssistant,
     entity_name: str,
-    area: str,
     domain: str,
+    area: str | None = None,
     *,
     exposed_entities: dict[str, dict[str, Any]],
 ) -> State:
     """Find an entity by its name or aliases."""
     entity_name_norm = entity_name.lower().strip()
-    area = area.lower().strip()
     domain = domain.lower().strip()
 
     for state in hass.states.async_all():
@@ -35,12 +34,14 @@ def find_entity_by_name(
             continue
 
         # Area filter
-        entity_info = exposed_entities[state.entity_id]
-        entity_areas = entity_info.get("areas")
-        if entity_areas:
-            area_list = [a.lower().strip() for a in entity_areas.split(", ")]
-            if area not in area_list:
-                continue
+        if area is not None:
+            area = area.lower().strip()
+            entity_info = exposed_entities[state.entity_id]
+            entity_areas = entity_info.get("areas")
+            if entity_areas:
+                area_list = [a.lower().strip() for a in entity_areas.split(", ")]
+                if area not in area_list:
+                    continue
 
         # Name matching
         entity_entry = er.async_get(hass).async_get(state.entity_id)

--- a/tests/test_entity_history.py
+++ b/tests/test_entity_history.py
@@ -48,7 +48,7 @@ def mock_recorder() -> tuple[MagicMock, MagicMock]:
         ) as mock_get_instance,
         patch(
             "custom_components.llm_intents.entity_history.async_get_exposed_entities",
-            new=AsyncMock(return_value={}),
+            new=MagicMock(return_value={}),
         ),
     ):
         mock_session = MagicMock()

--- a/tests/test_home_control.py
+++ b/tests/test_home_control.py
@@ -202,3 +202,62 @@ async def test_async_get_api_prompt_generates_correct_prompt(
             "You are in area Living Room (floor Upstairs) and all generic commands"
             in result
         )
+
+
+async def test_async_get_api_prompt_encloses_entity_names_in_backticks(
+    hass: HomeAssistant,
+    mock_llm_context_with_device: llm.LLMContext,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that entity names/aliases are wrapped in backticks in the rendered prompt."""
+    hass.data = {DOMAIN: {"config": {}}}
+    config_entry.add_to_hass(hass)
+
+    mock_llm_context_with_device.assistant = "assist_test"
+
+    exposed_entities = {
+        "light.living_room": {
+            "entity_id": "light.living_room",
+            "names": "Living Room Light, Living Room Lamp, LR Light",
+        },
+        "switch.garage": {"entity_id": "switch.garage", "names": "Garage Switch"},
+    }
+
+    device = MagicMock(spec=DeviceEntry)
+    device.area_id = "area_1"
+
+    device_reg = MagicMock(spec=DeviceRegistry)
+    device_reg.async_get = MagicMock(return_value=device)
+
+    area = MagicMock(spec=AreaEntry)
+    area.id = "area_1"
+    area.floor_id = None
+    area.name = "Living Room"
+
+    area_reg = MagicMock(spec=AreaRegistry)
+    area_reg.async_get_area = MagicMock(return_value=area)
+
+    floor_reg = MagicMock(spec=FloorRegistry)
+    floor_reg.async_get_floor = MagicMock(return_value=None)
+
+    with (
+        patch(
+            "homeassistant.helpers.device_registry.async_get", return_value=device_reg
+        ),
+        patch("homeassistant.helpers.area_registry.async_get", return_value=area_reg),
+        patch("homeassistant.helpers.floor_registry.async_get", return_value=floor_reg),
+        patch(
+            "custom_components.llm_intents.home_control.async_get_exposed_entities",
+            return_value=exposed_entities,
+        ),
+        patch(
+            "homeassistant.components.intent.async_device_supports_timers",
+            return_value=False,
+        ),
+    ):
+        api = HomeControlAPI(hass)
+        result = api._async_get_api_prompt(mock_llm_context_with_device)
+
+        assert "`Living Room Light`, `Living Room Lamp`, `LR Light`" in result
+        assert "`Garage Switch`" in result
+        assert "names:" in result


### PR DESCRIPTION
Also make area arg on history tool optional: not all entities have areas (eg people)